### PR TITLE
feat: add @eslint/v9-to-v10-custom-rules codemod

### DIFF
--- a/.changeset/v9-to-v10-custom-rules.md
+++ b/.changeset/v9-to-v10-custom-rules.md
@@ -1,0 +1,5 @@
+---
+'@eslint/v9-to-v10-custom-rules': minor
+---
+
+Add new codemod to migrate custom ESLint rules from v9 to v10. Replaces removed context methods, SourceCode methods, collapses v8→v9 fallback patterns, and flags no-replacement removals with TODO comments.

--- a/codemods/v10/custom-rules/README.md
+++ b/codemods/v10/custom-rules/README.md
@@ -13,9 +13,9 @@ ESLint v10 removes context methods and SourceCode methods that were deprecated i
 
 - ✅ **Removed context methods** — replaces `context.getFilename()`, `context.getPhysicalFilename()`, `context.getCwd()`, `context.getSourceCode()` with their property equivalents
 - ✅ **`context.parserOptions`** — replaces with `context.languageOptions.parserOptions`
-- ✅ **`context.parserPath`** — inserts a `// TODO` comment (no replacement exists)
+- ✅ **`context.parserPath`** — inserts a `/* TODO */` block comment (no replacement exists)
 - ✅ **v8→v9 fallback patterns** — collapses `context.filename ?? context.getFilename()` to `context.filename`
-- ✅ **Removed SourceCode methods** — replaces `getTokenOrCommentBefore`, `getTokenOrCommentAfter`, `isSpaceBetweenTokens`; inserts `// TODO` for `getJSDocComment`
+- ✅ **Removed SourceCode methods** — replaces `getTokenOrCommentBefore`, `getTokenOrCommentAfter`, `isSpaceBetweenTokens`; inserts `/* TODO */` block comment for `getJSDocComment`
 - ✅ **Optional `skip` argument** — correctly migrates `getTokenOrCommentBefore(node, skip)` to `getTokenBefore(node, { includeComments: true, skip })`
 
 ### Transformations

--- a/codemods/v10/custom-rules/README.md
+++ b/codemods/v10/custom-rules/README.md
@@ -1,0 +1,92 @@
+# @eslint/v9-to-v10-custom-rules
+
+Migrate custom ESLint rules from v9 to v10.
+
+## Overview
+
+> [!CAUTION]
+> Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that happen to use identifiers with the same method names.
+
+ESLint v10 removes context methods and SourceCode methods that were deprecated in v9. This codemod rewrites all removed API calls to their v10 equivalents.
+
+## What This Codemod Does
+
+- ✅ **Removed context methods** — replaces `context.getFilename()`, `context.getPhysicalFilename()`, `context.getCwd()`, `context.getSourceCode()` with their property equivalents
+- ✅ **`context.parserOptions`** — replaces with `context.languageOptions.parserOptions`
+- ✅ **`context.parserPath`** — inserts a `// TODO` comment (no replacement exists)
+- ✅ **v8→v9 fallback patterns** — collapses `context.filename ?? context.getFilename()` to `context.filename`
+- ✅ **Removed SourceCode methods** — replaces `getTokenOrCommentBefore`, `getTokenOrCommentAfter`, `isSpaceBetweenTokens`; inserts `// TODO` for `getJSDocComment`
+- ✅ **Optional `skip` argument** — correctly migrates `getTokenOrCommentBefore(node, skip)` to `getTokenBefore(node, { includeComments: true, skip })`
+
+### Transformations
+
+**Context methods:**
+
+```js
+// Before
+const file = context.getFilename()
+const phys = context.getPhysicalFilename()
+const cwd  = context.getCwd()
+const src  = context.getSourceCode()
+const opts = context.parserOptions
+
+// After
+const file = context.filename
+const phys = context.physicalFilename
+const cwd  = context.cwd
+const src  = context.sourceCode
+const opts = context.languageOptions.parserOptions
+```
+
+**v8→v9 fallback cleanup:**
+
+```js
+// Before (pattern emitted by the v8→v9 codemod)
+const file = context.filename ?? context.getFilename()
+
+// After
+const file = context.filename
+```
+
+**SourceCode methods:**
+
+```js
+// Before
+const before = sourceCode.getTokenOrCommentBefore(node)
+const after  = sourceCode.getTokenOrCommentAfter(node, 1)
+const space  = sourceCode.isSpaceBetweenTokens(tokenA, tokenB)
+const doc    = sourceCode.getJSDocComment(node)
+
+// After
+const before = sourceCode.getTokenBefore(node, { includeComments: true })
+const after  = sourceCode.getTokenAfter(node, { includeComments: true, skip: 1 })
+const space  = sourceCode.isSpaceBetween(tokenA, tokenB)
+const doc    = (null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)
+```
+
+## Usage
+
+```bash
+npx codemod @eslint/v9-to-v10-custom-rules
+```
+
+Or run locally from source:
+
+```bash
+npx codemod workflow run -w codemods/v10/custom-rules/workflow.yaml
+```
+
+## Manual Steps Required
+
+After running this codemod, search your files for `TODO` comments and address each one:
+
+| TODO comment | Action required |
+|---|---|
+| `context.parserPath removed in ESLint v10, no replacement` | Remove the usage. If you were checking the parser, use `context.languageOptions.parser` instead (the value is the parser object, not a path string) |
+| `getJSDocComment removed in ESLint v10, no replacement` | Remove the usage. If you need JSDoc information, use a third-party library or implement the logic manually using `sourceCode.getCommentsBefore(node)` |
+
+## Resources
+
+- [ESLint v10 migration guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0)
+- [Removal of deprecated context members — issue #16999](https://github.com/eslint/eslint/issues/16999)
+- [Removal of deprecated SourceCode methods — issue #20113](https://github.com/eslint/eslint/issues/20113)

--- a/codemods/v10/custom-rules/codemod.yaml
+++ b/codemods/v10/custom-rules/codemod.yaml
@@ -3,10 +3,10 @@ schema_version: '1.0'
 name: '@eslint/v9-to-v10-custom-rules'
 version: '1.0.0'
 description: 'Migrate custom ESLint rules from v9 to v10 format'
-author: 'ESLint Team'
+author: 'Rohit Khadatkar <khadatkarrohit@gmail.com>'
 license: 'MIT'
 workflow: 'workflow.yaml'
-repository: 'https://github.com/eslint/codemods/tree/main/codemods/v10/custom-rules'
+repository: 'https://github.com/eslint/codemods'
 
 targets:
   languages: ['typescript', 'javascript']

--- a/codemods/v10/custom-rules/codemod.yaml
+++ b/codemods/v10/custom-rules/codemod.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+
+name: '@eslint/v9-to-v10-custom-rules'
+version: '1.0.0'
+description: 'Migrate custom ESLint rules from v9 to v10 format'
+author: 'ESLint Team'
+license: 'MIT'
+workflow: 'workflow.yaml'
+repository: 'https://github.com/eslint/codemods/tree/main/codemods/v10/custom-rules'
+
+targets:
+  languages: ['typescript', 'javascript']
+
+keywords: ['transformation', 'migration', 'eslint', 'v9', 'v10']
+
+registry:
+  access: 'public'
+  visibility: 'public'
+
+capabilities: []

--- a/codemods/v10/custom-rules/package.json
+++ b/codemods/v10/custom-rules/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@eslint/v9-to-v10-custom-rules",
+  "version": "1.0.0",
+  "description": "Migrate custom ESLint rules from v9 to v10 format",
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "pnpm run test:context && pnpm run test:sourcecode",
+    "test:context": "codemod jssg test -l javascript ./scripts/replace-context-methods.ts --filter context",
+    "test:sourcecode": "codemod jssg test -l javascript ./scripts/replace-sourcecode-methods.ts --filter sourcecode"
+  },
+  "devDependencies": {
+    "@codemod.com/jssg-types": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/codemods/v10/custom-rules/scripts/replace-context-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-context-methods.ts
@@ -1,0 +1,160 @@
+import { type Edit, type RuleConfig, type SgNode, type SgRoot, parse } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// Method calls → direct property accesses
+const METHOD_TO_PROP: Record<string, string> = {
+  getFilename: 'filename',
+  getPhysicalFilename: 'physicalFilename',
+  getCwd: 'cwd',
+  getSourceCode: 'sourceCode',
+}
+
+const DEPRECATED_METHODS_REGEX = `^(${Object.keys(METHOD_TO_PROP).join('|')})$`
+
+// ── Selectors ──────────────────────────────────────────────────────────────
+
+function getFallbackPatternSelector(): RuleConfig<JS> {
+  // Matches: context.filename ?? context.getFilename()
+  // tree-sitter uses binary_expression for all binary operators incl. ??
+  return {
+    rule: {
+      kind: 'binary_expression',
+      has: {
+        kind: 'call_expression',
+        has: {
+          kind: 'member_expression',
+          has: {
+            kind: 'property_identifier',
+            regex: DEPRECATED_METHODS_REGEX,
+          },
+        },
+      },
+    },
+  }
+}
+
+function getMethodCallSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'call_expression',
+      has: {
+        kind: 'member_expression',
+        has: {
+          kind: 'property_identifier',
+          regex: DEPRECATED_METHODS_REGEX,
+        },
+      },
+    },
+  }
+}
+
+function getParserOptionsSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'member_expression',
+      has: {
+        kind: 'property_identifier',
+        regex: '^parserOptions$',
+      },
+      not: {
+        // skip languageOptions.parserOptions — already migrated
+        inside: {
+          kind: 'member_expression',
+          has: {
+            kind: 'property_identifier',
+            regex: '^languageOptions$',
+          },
+        },
+      },
+    },
+  }
+}
+
+function getParserPathSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'member_expression',
+      has: {
+        kind: 'property_identifier',
+        regex: '^parserPath$',
+      },
+    },
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function getPropertyName(memberExpr: SgNode<JS>): string {
+  const prop = memberExpr.find({ rule: { kind: 'property_identifier' } })
+  return prop?.text() ?? ''
+}
+
+function getSourceObject(memberExpr: SgNode<JS>): string {
+  const text = memberExpr.text()
+  const prop = getPropertyName(memberExpr)
+  return text.slice(0, text.lastIndexOf(`.${  prop}`))
+}
+
+function isNullishCoalescing(expr: SgNode<JS>): boolean {
+  return expr.children().some((c: SgNode<JS>) => c.text() === '??')
+}
+
+// ── Transform ──────────────────────────────────────────────────────────────
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const rootNode = root.root()
+
+  // ── Pass 1: collapse ?? fallback patterns ─────────────────────────────
+  // Must run before method call transforms to avoid overlapping edits.
+  // context.filename ?? context.getFilename() → context.filename
+  const fallbackEdits: Edit[] = []
+  for (const expr of rootNode.findAll(getFallbackPatternSelector())) {
+    if (!isNullishCoalescing(expr)) continue
+    const children = expr.children().filter((c: SgNode<JS>) => c.text() !== '??')
+    const left = children[0]
+    if (!left) continue
+    fallbackEdits.push(expr.replace(left.text()))
+  }
+
+  let text = rootNode.text()
+  if (fallbackEdits.length > 0) {
+    text = rootNode.commitEdits(fallbackEdits)
+  }
+
+  // Re-parse after pass 1 so subsequent selectors operate on updated AST
+  const updatedRoot = (parse('javascript', text)).root()
+  const mainEdits: Edit[] = []
+
+  // ── Pass 2: method call → property access ─────────────────────────────
+  // context.getFilename() → context.filename
+  for (const call of updatedRoot.findAll(getMethodCallSelector())) {
+    const memberExpr = call.find({ rule: { kind: 'member_expression' } })
+    if (!memberExpr) continue
+    const method = getPropertyName(memberExpr)
+    const prop = METHOD_TO_PROP[method]
+    if (!prop) continue
+    const src = getSourceObject(memberExpr)
+    mainEdits.push(call.replace(`${src}.${prop}`))
+  }
+
+  // ── Pass 3: context.parserOptions → context.languageOptions.parserOptions
+  for (const memberExpr of updatedRoot.findAll(getParserOptionsSelector())) {
+    const src = getSourceObject(memberExpr)
+    mainEdits.push(memberExpr.replace(`${src}.languageOptions.parserOptions`))
+  }
+
+  // ── Pass 4: context.parserPath — no replacement, flag with TODO ────────
+  for (const memberExpr of updatedRoot.findAll(getParserPathSelector())) {
+    const original = memberExpr.text()
+    mainEdits.push(
+      memberExpr.replace(`${original} /* TODO: context.parserPath removed in ESLint v10, no replacement */`),
+    )
+  }
+
+  if (mainEdits.length > 0) {
+    text = updatedRoot.commitEdits(mainEdits)
+  }
+
+  const changed = fallbackEdits.length > 0 || mainEdits.length > 0
+  return changed ? text : null
+}

--- a/codemods/v10/custom-rules/scripts/replace-context-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-context-methods.ts
@@ -92,7 +92,7 @@ function getPropertyName(memberExpr: SgNode<JS>): string {
 function getSourceObject(memberExpr: SgNode<JS>): string {
   const text = memberExpr.text()
   const prop = getPropertyName(memberExpr)
-  return text.slice(0, text.lastIndexOf(`.${  prop}`))
+  return text.slice(0, text.lastIndexOf(`.${prop}`))
 }
 
 function isNullishCoalescing(expr: SgNode<JS>): boolean {
@@ -110,9 +110,17 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   const fallbackEdits: Edit[] = []
   for (const expr of rootNode.findAll(getFallbackPatternSelector())) {
     if (!isNullishCoalescing(expr)) continue
+
     const children = expr.children().filter((c: SgNode<JS>) => c.text() !== '??')
     const left = children[0]
-    if (!left) continue
+    const right = children[1]
+    if (!left || !right) continue
+
+    // skip if the deprecated call is the left operand — pass 2 handles it
+    const rightText = right.text()
+    const rightHasDeprecatedCall = Object.keys(METHOD_TO_PROP).some((m) => rightText.includes(`.${m}(`))
+    if (!rightHasDeprecatedCall) continue
+
     fallbackEdits.push(expr.replace(left.text()))
   }
 
@@ -122,7 +130,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   }
 
   // Re-parse after pass 1 so subsequent selectors operate on updated AST
-  const updatedRoot = (parse('javascript', text)).root()
+  const updatedRoot = parse('javascript', text).root() as unknown as SgNode<JS>
   const mainEdits: Edit[] = []
 
   // ── Pass 2: method call → property access ─────────────────────────────

--- a/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
@@ -46,13 +46,18 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
 
     const method = propNode.text()
     const memberText = memberExpr.text()
-    const src = memberText.slice(0, memberText.lastIndexOf(`.${  method}`))
+    const src = memberText.slice(0, memberText.lastIndexOf(`.${method}`))
     const args = getCallArgs(call)
 
     if (method in RENAME) {
       const newMethod = RENAME[method] as string
       const skipPart = args[1] !== undefined ? `, skip: ${args[1]}` : ''
-      edits.push(call.replace(`${src}.${newMethod}(${args[0] ?? ''}, { includeComments: true${skipPart} })`))
+      const firstArg = args[0]
+      const replacement =
+        firstArg !== undefined
+          ? `${src}.${newMethod}(${firstArg}, { includeComments: true${skipPart} })`
+          : `${src}.${newMethod}({ includeComments: true${skipPart} })`
+      edits.push(call.replace(replacement))
     } else if (method === 'isSpaceBetweenTokens') {
       edits.push(call.replace(`${src}.isSpaceBetween(${args.join(', ')})`))
     } else if (method === 'getJSDocComment') {

--- a/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
@@ -1,0 +1,64 @@
+import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// Single source of truth — add a new entry here, nothing else changes
+const RENAME: Record<string, string> = {
+  getTokenOrCommentBefore: 'getTokenBefore',
+  getTokenOrCommentAfter: 'getTokenAfter',
+}
+
+const ALL_REMOVED = [...Object.keys(RENAME), 'isSpaceBetweenTokens', 'getJSDocComment']
+
+function getSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'call_expression',
+      has: {
+        kind: 'member_expression',
+        has: {
+          kind: 'property_identifier',
+          regex: `^(${ALL_REMOVED.join('|')})$`,
+        },
+      },
+    },
+  }
+}
+
+function getCallArgs(call: SgNode<JS>): string[] {
+  const argsNode = call.find({ rule: { kind: 'arguments' } })
+  if (!argsNode) return []
+  return argsNode
+    .children()
+    .filter((c: SgNode<JS>) => c.kind() !== '(' && c.kind() !== ')' && c.kind() !== ',')
+    .map((c: SgNode<JS>) => c.text())
+}
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const rootNode = root.root()
+  const edits: Edit[] = []
+
+  for (const call of rootNode.findAll(getSelector())) {
+    const memberExpr = call.find({ rule: { kind: 'member_expression' } })
+    if (!memberExpr) continue
+
+    const propNode = memberExpr.find({ rule: { kind: 'property_identifier' } })
+    if (!propNode) continue
+
+    const method = propNode.text()
+    const memberText = memberExpr.text()
+    const src = memberText.slice(0, memberText.lastIndexOf(`.${  method}`))
+    const args = getCallArgs(call)
+
+    if (method in RENAME) {
+      const newMethod = RENAME[method] as string
+      const skipPart = args[1] !== undefined ? `, skip: ${args[1]}` : ''
+      edits.push(call.replace(`${src}.${newMethod}(${args[0] ?? ''}, { includeComments: true${skipPart} })`))
+    } else if (method === 'isSpaceBetweenTokens') {
+      edits.push(call.replace(`${src}.isSpaceBetween(${args.join(', ')})`))
+    } else if (method === 'getJSDocComment') {
+      edits.push(call.replace(`(null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)`))
+    }
+  }
+
+  return edits.length > 0 ? rootNode.commitEdits(edits) : null
+}

--- a/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
@@ -38,10 +38,17 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   const edits: Edit[] = []
 
   for (const call of rootNode.findAll(getSelector())) {
-    const memberExpr = call.find({ rule: { kind: 'member_expression' } })
+    // Use children() to get the direct callee member_expression.
+    // find() uses DFS and returns the innermost nested member_expression first,
+    // so for a double-level callee like ctx.sourceCode.deprecated() it would
+    // return ctx.sourceCode and extract 'sourceCode' as the method name — skipping
+    // the transform entirely. children() returns only direct children of the call.
+    const memberExpr = call.children().find((c: SgNode<JS>) => c.kind() === 'member_expression') ?? null
     if (!memberExpr) continue
 
-    const propNode = memberExpr.find({ rule: { kind: 'property_identifier' } })
+    // Same reason: use children() to get the direct property identifier of the callee,
+    // not a property identifier nested inside the object part of the member expression.
+    const propNode = memberExpr.children().find((c: SgNode<JS>) => c.kind() === 'property_identifier') ?? null
     if (!propNode) continue
 
     const method = propNode.text()

--- a/codemods/v10/custom-rules/tests/context-basic/expected.js
+++ b/codemods/v10/custom-rules/tests/context-basic/expected.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const file = context.filename
+        const phys = context.physicalFilename
+        const cwd = context.cwd
+        const src = context.sourceCode
+        const opts = context.languageOptions.parserOptions
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/context-basic/input.js
+++ b/codemods/v10/custom-rules/tests/context-basic/input.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const file = context.getFilename()
+        const phys = context.getPhysicalFilename()
+        const cwd = context.getCwd()
+        const src = context.getSourceCode()
+        const opts = context.parserOptions
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/context-fallback-cleanup/expected.js
+++ b/codemods/v10/custom-rules/tests/context-fallback-cleanup/expected.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const file = context.filename
+        const phys = context.physicalFilename
+        const cwd = context.cwd
+        const src = context.sourceCode
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/context-fallback-cleanup/input.js
+++ b/codemods/v10/custom-rules/tests/context-fallback-cleanup/input.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const file = context.filename ?? context.getFilename()
+        const phys = context.physicalFilename ?? context.getPhysicalFilename()
+        const cwd = context.cwd ?? context.getCwd()
+        const src = context.sourceCode ?? context.getSourceCode()
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/context-parserpath/expected.js
+++ b/codemods/v10/custom-rules/tests/context-parserpath/expected.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const parser = context.parserPath /* TODO: context.parserPath removed in ESLint v10, no replacement */
+        if (context.parserPath /* TODO: context.parserPath removed in ESLint v10, no replacement */ === 'espree') {
+          return
+        }
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/context-parserpath/input.js
+++ b/codemods/v10/custom-rules/tests/context-parserpath/input.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    return {
+      Program() {
+        const parser = context.parserPath
+        if (context.parserPath === 'espree') {
+          return
+        }
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-basic/expected.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-basic/expected.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const before = sourceCode.getTokenBefore(node, { includeComments: true })
+        const after = sourceCode.getTokenAfter(node, { includeComments: true })
+        const space = sourceCode.isSpaceBetween(before, after)
+        const doc = (null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-basic/input.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-basic/input.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const before = sourceCode.getTokenOrCommentBefore(node)
+        const after = sourceCode.getTokenOrCommentAfter(node)
+        const space = sourceCode.isSpaceBetweenTokens(before, after)
+        const doc = sourceCode.getJSDocComment(node)
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-chained/expected.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-chained/expected.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const value = sourceCode.getTokenBefore(node, { includeComments: true }).value
+        const type = sourceCode.getTokenAfter(node, { includeComments: true }).type
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-chained/input.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-chained/input.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const value = sourceCode.getTokenOrCommentBefore(node).value
+        const type = sourceCode.getTokenOrCommentAfter(node).type
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-skip-arg/expected.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-skip-arg/expected.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const before = sourceCode.getTokenBefore(node, { includeComments: true, skip: 1 })
+        const after = sourceCode.getTokenAfter(node, { includeComments: true, skip: 2 })
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-skip-arg/input.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-skip-arg/input.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      CallExpression(node) {
+        const before = sourceCode.getTokenOrCommentBefore(node, 1)
+        const after = sourceCode.getTokenOrCommentAfter(node, 2)
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tsconfig.json
+++ b/codemods/v10/custom-rules/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@codemod.com/jssg-types", "node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/codemods/v10/custom-rules/workflow.yaml
+++ b/codemods/v10/custom-rules/workflow.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod/codemod/refs/heads/main/schemas/workflow.json
+
+version: '1'
+
+nodes:
+  - id: apply-transforms
+    name: Apply ESLint v9 to v10 Custom Rules Migration
+    type: automatic
+    steps:
+      - id: replace-context-methods
+        name: 'Replace removed context methods'
+        js-ast-grep:
+          js_file: scripts/replace-context-methods.ts
+          include:
+            - '**/*.ts'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'
+      - id: replace-sourcecode-methods
+        name: 'Replace removed SourceCode methods'
+        depends_on:
+          - replace-context-methods
+        js-ast-grep:
+          js_file: scripts/replace-sourcecode-methods.ts
+          include:
+            - '**/*.ts'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,18 @@ importers:
         specifier: ^5.8.3
         version: 5.9.2
 
+  codemods/v10/custom-rules:
+    devDependencies:
+      '@codemod.com/jssg-types':
+        specifier: 'catalog:'
+        version: 1.6.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   codemods/v9/config-file:
     dependencies:
       '@types/js-yaml':


### PR DESCRIPTION
## Summary

ESLint v10 removed several APIs that were only deprecated in v9. Any plugin or custom rule that still calls these APIs will throw a `TypeError` at runtime after upgrading to v10.

This PR adds a new codemod `@eslint/v9-to-v10-custom-rules` that automatically rewrites those deprecated calls so plugin authors can upgrade without touching their code manually.

## What it transforms

**Removed context methods → properties**

```js
// Before
context.getFilename()
context.getPhysicalFilename()
context.getCwd()
context.getSourceCode()
context.parserOptions

// After
context.filename
context.physicalFilename
context.cwd
context.sourceCode
context.languageOptions.parserOptions
```

**Removed SourceCode methods**

```js
// Before
sourceCode.getTokenOrCommentBefore(node)
sourceCode.getTokenOrCommentBefore(node, 1)   // optional skip arg
sourceCode.getTokenOrCommentAfter(node)
sourceCode.isSpaceBetweenTokens(a, b)
sourceCode.getJSDocComment(node)              // no replacement

// After
sourceCode.getTokenBefore(node, { includeComments: true })
sourceCode.getTokenBefore(node, { includeComments: true, skip: 1 })
sourceCode.getTokenAfter(node, { includeComments: true })
sourceCode.isSpaceBetween(a, b)
(null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)
```

**Cleans up fallback patterns from the v8→v9 codemod**

```js
// Before (pattern the v8→v9 codemod emitted as a safe fallback)
context.filename ?? context.getFilename()

// After
context.filename
```

## How to use

```bash
npx codemod @eslint/v9-to-v10-custom-rules
```

## Testing

6 fixtures covering all transform cases including the optional `skip` argument, chained access, and `??` fallback cleanup.

```bash
pnpm --filter @eslint/v9-to-v10-custom-rules test
pnpm --filter @eslint/v9-to-v10-custom-rules check-types
```

All tests pass. No regressions in existing v9 codemods (`pnpm run ci` green).

## Related

- Removes deprecated APIs listed in the [ESLint v10 migration guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0)
- Implementing PRs in eslint/eslint: [#20086](https://github.com/eslint/eslint/issues/20086) (context methods), [#20113](https://github.com/eslint/eslint/issues/20113) (SourceCode methods)
