### PR TITLE
feat: add @eslint/v9-to-v10-ruletester codemod

### DIFF
--- a/.changeset/v9-to-v10-ruletester.md
+++ b/.changeset/v9-to-v10-ruletester.md
@@ -2,4 +2,4 @@
 '@eslint/v9-to-v10-ruletester': minor
 ---
 
-Add new codemod to fix RuleTester test case structure for ESLint v10. Removes `errors` and `output` properties from valid test cases, and removes the `type` property from invalid test cases — all of which v10 now throws on.
+Add new codemod to fix RuleTester test case structure for ESLint v10. Removes `errors` and `output` properties from valid test cases, and removes the `type` property from error matcher objects inside `errors[]` of invalid test cases — all of which v10 now throws on.

--- a/.changeset/v9-to-v10-ruletester.md
+++ b/.changeset/v9-to-v10-ruletester.md
@@ -1,0 +1,5 @@
+---
+'@eslint/v9-to-v10-ruletester': minor
+---
+
+Add new codemod to fix RuleTester test case structure for ESLint v10. Removes `errors` and `output` properties from valid test cases, and removes the `type` property from invalid test cases — all of which v10 now throws on.

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -6,16 +6,9 @@ function excludeLockfiles(files) {
 }
 
 export default {
-  /** @param {string[]} files */
-  '*.{ts,tsx,js,jsx,mts,mjs}': (files) => {
-    const formattable = files.filter((f) => !f.includes('/tests/'))
-    const cmds = []
-    if (formattable.length) {
-      cmds.push(`oxfmt --write ${formattable.join(' ')}`)
-    }
-    cmds.push(`oxlint --type-aware --type-check --fix ${files.join(' ')}`)
-    return cmds
-  },
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'oxfmt --write',
+  '*.{js,mjs,cjs,jsx}': 'oxlint --fix',
+  '*.{ts,mts,cts,tsx}': 'oxlint --type-aware --type-check --fix',
   /** @param {string[]} files */
   '*.{json,yaml,yml}': (files) => {
     const filtered = excludeLockfiles(files)

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -8,9 +8,11 @@ function excludeLockfiles(files) {
 export default {
   /** @param {string[]} files */
   '*.{ts,tsx,js,jsx,mts,mjs}': (files) => {
-    const formattable = files.filter((f) => !f.includes('\/tests\/'))
+    const formattable = files.filter((f) => !f.includes('/tests/'))
     const cmds = []
-    if (formattable.length) {cmds.push(`oxfmt --write ${formattable.join(' ')}`)}
+    if (formattable.length) {
+      cmds.push(`oxfmt --write ${formattable.join(' ')}`)
+    }
     cmds.push(`oxlint --type-aware --type-check --fix ${files.join(' ')}`)
     return cmds
   },

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -6,7 +6,14 @@ function excludeLockfiles(files) {
 }
 
 export default {
-  '*.{ts,tsx,js,jsx,mts,mjs}': ['oxfmt --write', 'oxlint --type-aware --type-check --fix'],
+  /** @param {string[]} files */
+  '*.{ts,tsx,js,jsx,mts,mjs}': (files) => {
+    const formattable = files.filter((f) => !f.includes('\/tests\/'))
+    const cmds = []
+    if (formattable.length) {cmds.push(`oxfmt --write ${formattable.join(' ')}`)}
+    cmds.push(`oxlint --type-aware --type-check --fix ${files.join(' ')}`)
+    return cmds
+  },
   /** @param {string[]} files */
   '*.{json,yaml,yml}': (files) => {
     const filtered = excludeLockfiles(files)

--- a/codemods/v10/custom-rules/README.md
+++ b/codemods/v10/custom-rules/README.md
@@ -26,15 +26,15 @@ ESLint v10 removes context methods and SourceCode methods that were deprecated i
 // Before
 const file = context.getFilename()
 const phys = context.getPhysicalFilename()
-const cwd  = context.getCwd()
-const src  = context.getSourceCode()
+const cwd = context.getCwd()
+const src = context.getSourceCode()
 const opts = context.parserOptions
 
 // After
 const file = context.filename
 const phys = context.physicalFilename
-const cwd  = context.cwd
-const src  = context.sourceCode
+const cwd = context.cwd
+const src = context.sourceCode
 const opts = context.languageOptions.parserOptions
 ```
 
@@ -53,15 +53,15 @@ const file = context.filename
 ```js
 // Before
 const before = sourceCode.getTokenOrCommentBefore(node)
-const after  = sourceCode.getTokenOrCommentAfter(node, 1)
-const space  = sourceCode.isSpaceBetweenTokens(tokenA, tokenB)
-const doc    = sourceCode.getJSDocComment(node)
+const after = sourceCode.getTokenOrCommentAfter(node, 1)
+const space = sourceCode.isSpaceBetweenTokens(tokenA, tokenB)
+const doc = sourceCode.getJSDocComment(node)
 
 // After
 const before = sourceCode.getTokenBefore(node, { includeComments: true })
-const after  = sourceCode.getTokenAfter(node, { includeComments: true, skip: 1 })
-const space  = sourceCode.isSpaceBetween(tokenA, tokenB)
-const doc    = (null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)
+const after = sourceCode.getTokenAfter(node, { includeComments: true, skip: 1 })
+const space = sourceCode.isSpaceBetween(tokenA, tokenB)
+const doc = null /* TODO: getJSDocComment removed in ESLint v10, no replacement */
 ```
 
 ## Usage
@@ -80,10 +80,10 @@ npx codemod workflow run -w codemods/v10/custom-rules/workflow.yaml
 
 After running this codemod, search your files for `TODO` comments and address each one:
 
-| TODO comment | Action required |
-|---|---|
-| `context.parserPath removed in ESLint v10, no replacement` | Remove the usage. If you were checking the parser, use `context.languageOptions.parser` instead (the value is the parser object, not a path string) |
-| `getJSDocComment removed in ESLint v10, no replacement` | Remove the usage. If you need JSDoc information, use a third-party library or implement the logic manually using `sourceCode.getCommentsBefore(node)` |
+| TODO comment                                               | Action required                                                                                                                                       |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context.parserPath removed in ESLint v10, no replacement` | Remove the usage. If you were checking the parser, use `context.languageOptions.parser` instead (the value is the parser object, not a path string)   |
+| `getJSDocComment removed in ESLint v10, no replacement`    | Remove the usage. If you need JSDoc information, use a third-party library or implement the logic manually using `sourceCode.getCommentsBefore(node)` |
 
 ## Resources
 

--- a/codemods/v10/ruletester/README.md
+++ b/codemods/v10/ruletester/README.md
@@ -19,16 +19,12 @@ ESLint v10 throws an error when `RuleTester` test case objects contain propertie
 ```js
 // Before
 ruleTester.run('my-rule', rule, {
-  valid: [
-    { code: 'var x = 1', errors: [], output: null },
-  ],
+  valid: [{ code: 'var x = 1', errors: [], output: null }],
 })
 
 // After
 ruleTester.run('my-rule', rule, {
-  valid: [
-    { code: 'var x = 1' },
-  ],
+  valid: [{ code: 'var x = 1' }],
 })
 ```
 
@@ -37,16 +33,12 @@ ruleTester.run('my-rule', rule, {
 ```js
 // Before
 ruleTester.run('my-rule', rule, {
-  invalid: [
-    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
-  ],
+  invalid: [{ code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] }],
 })
 
 // After
 ruleTester.run('my-rule', rule, {
-  invalid: [
-    { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
-  ],
+  invalid: [{ code: 'eval(x)', errors: [{ messageId: 'noEval' }] }],
 })
 ```
 

--- a/codemods/v10/ruletester/README.md
+++ b/codemods/v10/ruletester/README.md
@@ -4,9 +4,6 @@ Fix RuleTester test case structure for ESLint v10.
 
 ## Overview
 
-> [!CAUTION]
-> Run this codemod only in directories containing ESLint rule test files. It removes properties from `RuleTester` test case objects — running it on unrelated code risks false positives if those properties appear inside `valid` or `invalid` arrays in other contexts.
-
 ESLint v10 throws an error when `RuleTester` test case objects contain properties that were silently ignored in v9. This codemod removes those properties automatically.
 
 ## What This Codemod Does

--- a/codemods/v10/ruletester/README.md
+++ b/codemods/v10/ruletester/README.md
@@ -1,6 +1,6 @@
 # @eslint/v9-to-v10-ruletester
 
-Fix RuleTester test case structure for ESLint v10.
+Fix `RuleTester` test case structure for ESLint v10.
 
 ## Overview
 

--- a/codemods/v10/ruletester/README.md
+++ b/codemods/v10/ruletester/README.md
@@ -57,5 +57,5 @@ npx codemod workflow run -w codemods/v10/ruletester/workflow.yaml
 ## Resources
 
 - [ESLint v10 migration guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0)
-- [Removal of `type` in invalid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#removal-of-type-property-in-errors-of-invalid-ruletester-cases)
-- [Prohibiting `errors`/`output` in valid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#prohibiting-errors-or-output-of-valid-ruletester-test-cases)
+- [Removal of `type` in invalid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#ruletester-type-removed)
+- [Prohibiting `errors`/`output` in valid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#stricter-rule-tester)

--- a/codemods/v10/ruletester/README.md
+++ b/codemods/v10/ruletester/README.md
@@ -1,0 +1,72 @@
+# @eslint/v9-to-v10-ruletester
+
+Fix RuleTester test case structure for ESLint v10.
+
+## Overview
+
+> [!CAUTION]
+> Run this codemod only in directories containing ESLint rule test files. It removes properties from `RuleTester` test case objects — running it on unrelated code risks false positives if those properties appear inside `valid` or `invalid` arrays in other contexts.
+
+ESLint v10 throws an error when `RuleTester` test case objects contain properties that were silently ignored in v9. This codemod removes those properties automatically.
+
+## What This Codemod Does
+
+- ✅ **`errors` in valid cases** — removes `errors` property from objects inside `valid` arrays (v10 throws if present)
+- ✅ **`output` in valid cases** — removes `output` property from objects inside `valid` arrays (v10 throws if present)
+- ✅ **`type` in invalid cases** — removes `type` property from objects inside `invalid` arrays (v10 throws if present)
+
+### Transformations
+
+**Valid cases — remove `errors` and `output`:**
+
+```js
+// Before
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1', errors: [], output: null },
+  ],
+})
+
+// After
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1' },
+  ],
+})
+```
+
+**Invalid cases — remove `type`:**
+
+```js
+// Before
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
+  ],
+})
+
+// After
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
+  ],
+})
+```
+
+## Usage
+
+```bash
+npx codemod @eslint/v9-to-v10-ruletester
+```
+
+Or run locally from source:
+
+```bash
+npx codemod workflow run -w codemods/v10/ruletester/workflow.yaml
+```
+
+## Resources
+
+- [ESLint v10 migration guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0)
+- [Removal of `type` in invalid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#removal-of-type-property-in-errors-of-invalid-ruletester-cases)
+- [Prohibiting `errors`/`output` in valid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#prohibiting-errors-or-output-of-valid-ruletester-test-cases)

--- a/codemods/v10/ruletester/codemod.yaml
+++ b/codemods/v10/ruletester/codemod.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+
+name: '@eslint/v9-to-v10-ruletester'
+version: '1.0.0'
+description: 'Fix RuleTester test case structure for ESLint v10'
+author: 'Rohit Khadatkar <khadatkarrohit@gmail.com>'
+license: 'MIT'
+workflow: 'workflow.yaml'
+repository: 'https://github.com/eslint/codemods'
+
+targets:
+  languages: ['typescript', 'javascript']
+
+keywords: ['transformation', 'migration', 'eslint', 'v9', 'v10']
+
+registry:
+  access: 'public'
+  visibility: 'public'
+
+capabilities: []

--- a/codemods/v10/ruletester/package.json
+++ b/codemods/v10/ruletester/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@eslint/v9-to-v10-ruletester",
+  "version": "1.0.0",
+  "description": "Fix RuleTester test case structure for ESLint v10",
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "pnpm run test:valid && pnpm run test:invalid",
+    "test:valid": "codemod jssg test -l javascript ./scripts/cleanup-valid-cases.ts --filter cleanup-valid",
+    "test:invalid": "codemod jssg test -l javascript ./scripts/cleanup-invalid-cases.ts --filter cleanup-invalid"
+  },
+  "devDependencies": {
+    "@codemod.com/jssg-types": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -72,7 +72,7 @@ function removePairEdit(pair: SgNode<JS>, source: string): Edit {
 
   // First property — remove trailing comma instead
   const after = source.slice(end)
-  const trailingComma = after.match(/^\s*,/)
+  const trailingComma = after.match(/^\s*,\s*/)
 
   if (trailingComma) {
     return {

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -19,6 +19,22 @@ function getSelector(): RuleConfig<JS> {
               kind: 'property_identifier',
               regex: '^invalid$',
             },
+            inside: {
+              kind: 'object',
+              inside: {
+                kind: 'arguments',
+                inside: {
+                  kind: 'call_expression',
+                  has: {
+                    kind: 'member_expression',
+                    has: {
+                      kind: 'property_identifier',
+                      regex: '^run$',
+                    },
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -1,46 +1,44 @@
-import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
-function getSelector(): RuleConfig<JS> {
-  return {
-    rule: {
-      kind: 'pair',
-      has: {
-        kind: 'property_identifier',
-        regex: '^type$',
-      },
+const selector = {
+  rule: {
+    kind: 'pair',
+    has: {
+      kind: 'property_identifier',
+      regex: '^type$',
+    },
+    inside: {
+      kind: 'object',
       inside: {
-        kind: 'object',
+        kind: 'array',
         inside: {
-          kind: 'array',
+          kind: 'pair',
+          has: {
+            kind: 'property_identifier',
+            regex: '^errors$',
+          },
           inside: {
-            kind: 'pair',
-            has: {
-              kind: 'property_identifier',
-              regex: '^errors$',
-            },
+            kind: 'object',
             inside: {
-              kind: 'object',
+              kind: 'array',
               inside: {
-                kind: 'array',
+                kind: 'pair',
+                has: {
+                  kind: 'property_identifier',
+                  regex: '^invalid$',
+                },
                 inside: {
-                  kind: 'pair',
-                  has: {
-                    kind: 'property_identifier',
-                    regex: '^invalid$',
-                  },
+                  kind: 'object',
                   inside: {
-                    kind: 'object',
+                    kind: 'arguments',
                     inside: {
-                      kind: 'arguments',
-                      inside: {
-                        kind: 'call_expression',
+                      kind: 'call_expression',
+                      has: {
+                        kind: 'member_expression',
                         has: {
-                          kind: 'member_expression',
-                          has: {
-                            kind: 'property_identifier',
-                            regex: '^run$',
-                          },
+                          kind: 'property_identifier',
+                          regex: '^run$',
                         },
                       },
                     },
@@ -52,44 +50,53 @@ function getSelector(): RuleConfig<JS> {
         },
       },
     },
-  }
-}
+  },
+} as const satisfies RuleConfig<JS>
 
-function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
-  const r = pair.range()
-  const start = r.start.index
-  const end = r.end.index
+function removePairEdit(pair: SgNode<JS>, source: string): Edit {
+  const range = pair.range()
+  const start = range.start.index
+  const end = range.end.index
 
   // Prefer removing the preceding comma so the trailing element keeps its comma
   const before = source.slice(0, start)
   const precedingComma = before.match(/,\s*$/)
+
   if (precedingComma) {
-    return { start: start - precedingComma[0].length, end }
+    return {
+      startPos: start - precedingComma[0].length,
+      endPos: end,
+      insertedText: '',
+    }
   }
 
   // First property — remove trailing comma instead
   const after = source.slice(end)
   const trailingComma = after.match(/^\s*,/)
+
   if (trailingComma) {
-    return { start, end: end + trailingComma[0].length }
+    return {
+      startPos: start,
+      endPos: end + trailingComma[0].length,
+      insertedText: '',
+    }
   }
 
-  return { start, end }
+  return {
+    startPos: start,
+    endPos: end,
+    insertedText: '',
+  }
 }
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
   const rootNode = root.root()
-  const pairs = rootNode.findAll(getSelector())
+  const pairs = rootNode.findAll(selector)
 
   if (pairs.length === 0) return null
 
   const source = rootNode.text()
-  const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
+  const edits = pairs.map((pair) => removePairEdit(pair, source))
 
-  let result = source
-  for (const { start, end } of deletions) {
-    result = result.slice(0, start) + result.slice(end)
-  }
-
-  return result
+  return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -1,0 +1,66 @@
+import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+function getSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'pair',
+      has: {
+        kind: 'property_identifier',
+        regex: '^type$',
+      },
+      inside: {
+        kind: 'object',
+        inside: {
+          kind: 'array',
+          inside: {
+            kind: 'pair',
+            has: {
+              kind: 'property_identifier',
+              regex: '^invalid$',
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
+function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
+  const r = pair.range()
+  const start = r.start.index
+  const end = r.end.index
+
+  // Prefer removing the preceding comma so the trailing element keeps its comma
+  const before = source.slice(0, start)
+  const precedingComma = before.match(/,\s*$/)
+  if (precedingComma) {
+    return { start: start - precedingComma[0].length, end }
+  }
+
+  // First property — remove trailing comma instead
+  const after = source.slice(end)
+  const trailingComma = after.match(/^\s*,/)
+  if (trailingComma) {
+    return { start, end: end + trailingComma[0].length }
+  }
+
+  return { start, end }
+}
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const rootNode = root.root()
+  const pairs = rootNode.findAll(getSelector())
+
+  if (pairs.length === 0) return null
+
+  const source = rootNode.text()
+  const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
+
+  let result = source
+  for (const { start, end } of deletions) {
+    result = result.slice(0, start) + result.slice(end)
+  }
+
+  return result
+}

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -9,6 +9,18 @@ function getSelector(): RuleConfig<JS> {
         kind: 'property_identifier',
         regex: '^type$',
       },
+      not: {
+        inside: {
+          kind: 'array',
+          inside: {
+            kind: 'pair',
+            has: {
+              kind: 'property_identifier',
+              regex: '^errors$',
+            },
+          },
+        },
+      },
       inside: {
         kind: 'object',
         inside: {

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -9,18 +9,6 @@ function getSelector(): RuleConfig<JS> {
         kind: 'property_identifier',
         regex: '^type$',
       },
-      not: {
-        inside: {
-          kind: 'array',
-          inside: {
-            kind: 'pair',
-            has: {
-              kind: 'property_identifier',
-              regex: '^errors$',
-            },
-          },
-        },
-      },
       inside: {
         kind: 'object',
         inside: {
@@ -29,19 +17,32 @@ function getSelector(): RuleConfig<JS> {
             kind: 'pair',
             has: {
               kind: 'property_identifier',
-              regex: '^invalid$',
+              regex: '^errors$',
             },
             inside: {
               kind: 'object',
               inside: {
-                kind: 'arguments',
+                kind: 'array',
                 inside: {
-                  kind: 'call_expression',
+                  kind: 'pair',
                   has: {
-                    kind: 'member_expression',
-                    has: {
-                      kind: 'property_identifier',
-                      regex: '^run$',
+                    kind: 'property_identifier',
+                    regex: '^invalid$',
+                  },
+                  inside: {
+                    kind: 'object',
+                    inside: {
+                      kind: 'arguments',
+                      inside: {
+                        kind: 'call_expression',
+                        has: {
+                          kind: 'member_expression',
+                          has: {
+                            kind: 'property_identifier',
+                            regex: '^run$',
+                          },
+                        },
+                      },
                     },
                   },
                 },

--- a/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
@@ -62,7 +62,7 @@ function removePairEdit(pair: SgNode<JS>, source: string): Edit {
 
   // First property — remove trailing comma instead
   const after = source.slice(end)
-  const trailingComma = after.match(/^\s*,/)
+  const trailingComma = after.match(/^\s*,\s*/)
 
   if (trailingComma) {
     return {

--- a/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
@@ -1,39 +1,37 @@
-import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 // Properties that v10 throws on when present in a valid test case
 const PROPS_TO_REMOVE = ['errors', 'output']
 
-function getSelector(): RuleConfig<JS> {
-  return {
-    rule: {
-      kind: 'pair',
-      has: {
-        kind: 'property_identifier',
-        regex: `^(${PROPS_TO_REMOVE.join('|')})$`,
-      },
+const selector = {
+  rule: {
+    kind: 'pair',
+    has: {
+      kind: 'property_identifier',
+      regex: `^(?:${PROPS_TO_REMOVE.join('|')})$`,
+    },
+    inside: {
+      kind: 'object',
       inside: {
-        kind: 'object',
+        kind: 'array',
         inside: {
-          kind: 'array',
+          kind: 'pair',
+          has: {
+            kind: 'property_identifier',
+            regex: '^valid$',
+          },
           inside: {
-            kind: 'pair',
-            has: {
-              kind: 'property_identifier',
-              regex: '^valid$',
-            },
+            kind: 'object',
             inside: {
-              kind: 'object',
+              kind: 'arguments',
               inside: {
-                kind: 'arguments',
-                inside: {
-                  kind: 'call_expression',
+                kind: 'call_expression',
+                has: {
+                  kind: 'member_expression',
                   has: {
-                    kind: 'member_expression',
-                    has: {
-                      kind: 'property_identifier',
-                      regex: '^run$',
-                    },
+                    kind: 'property_identifier',
+                    regex: '^run$',
                   },
                 },
               },
@@ -42,44 +40,53 @@ function getSelector(): RuleConfig<JS> {
         },
       },
     },
-  }
-}
+  },
+} as const satisfies RuleConfig<JS>
 
-function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
-  const r = pair.range()
-  const start = r.start.index
-  const end = r.end.index
+function removePairEdit(pair: SgNode<JS>, source: string): Edit {
+  const range = pair.range()
+  const start = range.start.index
+  const end = range.end.index
 
   // Prefer removing the preceding comma so the trailing element keeps its comma
   const before = source.slice(0, start)
   const precedingComma = before.match(/,\s*$/)
+
   if (precedingComma) {
-    return { start: start - precedingComma[0].length, end }
+    return {
+      startPos: start - precedingComma[0].length,
+      endPos: end,
+      insertedText: '',
+    }
   }
 
   // First property — remove trailing comma instead
   const after = source.slice(end)
   const trailingComma = after.match(/^\s*,/)
+
   if (trailingComma) {
-    return { start, end: end + trailingComma[0].length }
+    return {
+      startPos: start,
+      endPos: end + trailingComma[0].length,
+      insertedText: '',
+    }
   }
 
-  return { start, end }
+  return {
+    startPos: start,
+    endPos: end,
+    insertedText: '',
+  }
 }
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
   const rootNode = root.root()
-  const pairs = rootNode.findAll(getSelector())
+  const pairs = rootNode.findAll(selector)
 
   if (pairs.length === 0) return null
 
   const source = rootNode.text()
-  const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
+  const edits = pairs.map((pair) => removePairEdit(pair, source))
 
-  let result = source
-  for (const { start, end } of deletions) {
-    result = result.slice(0, start) + result.slice(end)
-  }
-
-  return result
+  return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
@@ -1,0 +1,69 @@
+import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// Properties that v10 throws on when present in a valid test case
+const PROPS_TO_REMOVE = ['errors', 'output']
+
+function getSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'pair',
+      has: {
+        kind: 'property_identifier',
+        regex: `^(${PROPS_TO_REMOVE.join('|')})$`,
+      },
+      inside: {
+        kind: 'object',
+        inside: {
+          kind: 'array',
+          inside: {
+            kind: 'pair',
+            has: {
+              kind: 'property_identifier',
+              regex: '^valid$',
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
+function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
+  const r = pair.range()
+  const start = r.start.index
+  const end = r.end.index
+
+  // Prefer removing the preceding comma so the trailing element keeps its comma
+  const before = source.slice(0, start)
+  const precedingComma = before.match(/,\s*$/)
+  if (precedingComma) {
+    return { start: start - precedingComma[0].length, end }
+  }
+
+  // First property — remove trailing comma instead
+  const after = source.slice(end)
+  const trailingComma = after.match(/^\s*,/)
+  if (trailingComma) {
+    return { start, end: end + trailingComma[0].length }
+  }
+
+  return { start, end }
+}
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const rootNode = root.root()
+  const pairs = rootNode.findAll(getSelector())
+
+  if (pairs.length === 0) return null
+
+  const source = rootNode.text()
+  const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
+
+  let result = source
+  for (const { start, end } of deletions) {
+    result = result.slice(0, start) + result.slice(end)
+  }
+
+  return result
+}

--- a/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-valid-cases.ts
@@ -22,6 +22,22 @@ function getSelector(): RuleConfig<JS> {
               kind: 'property_identifier',
               regex: '^valid$',
             },
+            inside: {
+              kind: 'object',
+              inside: {
+                kind: 'arguments',
+                inside: {
+                  kind: 'call_expression',
+                  has: {
+                    kind: 'member_expression',
+                    has: {
+                      kind: 'property_identifier',
+                      regex: '^run$',
+                    },
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
@@ -1,16 +1,13 @@
+// type inside errors[] is removed; type in valid cases or unrelated objects is not touched
 ruleTester.run('my-rule', rule, {
+  valid: [
+    // type in valid cases must not be touched (different script handles valid cases)
+    { code: 'foo', options: [{ type: 'bar' }] },
+  ],
   invalid: [
-    // top-level type removed, type inside errors[i] must be preserved
-    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    // type only inside errors[i] - must not be touched at all
-    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    // multiple errors: type in first entry only
-    {
-      code: 'eval(z)',
-      errors: [
-        { messageId: 'noEval', type: 'CallExpression' },
-        { messageId: 'noEval' },
-      ],
-    },
+    // type inside errors[] must be removed
+    { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
+    // type in options must not be touched
+    { code: 'eval(y)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
@@ -1,0 +1,16 @@
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    // top-level type removed, type inside errors[i] must be preserved
+    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // type only inside errors[i] - must not be touched at all
+    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // multiple errors: type in first entry only
+    {
+      code: 'eval(z)',
+      errors: [
+        { messageId: 'noEval', type: 'CallExpression' },
+        { messageId: 'noEval' },
+      ],
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
@@ -1,0 +1,17 @@
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    // top-level type removed, type inside errors[i] must be preserved
+    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // type only inside errors[i] - must not be touched at all
+    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // multiple errors: type in first entry only
+    {
+      code: 'eval(z)',
+      type: 'CallExpression',
+      errors: [
+        { messageId: 'noEval', type: 'CallExpression' },
+        { messageId: 'noEval' },
+      ],
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
@@ -1,17 +1,13 @@
+// type inside errors[] is removed; type in valid cases or unrelated objects is not touched
 ruleTester.run('my-rule', rule, {
+  valid: [
+    // type in valid cases must not be touched (different script handles valid cases)
+    { code: 'foo', options: [{ type: 'bar' }] },
+  ],
   invalid: [
-    // top-level type removed, type inside errors[i] must be preserved
-    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    // type only inside errors[i] - must not be touched at all
-    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    // multiple errors: type in first entry only
-    {
-      code: 'eval(z)',
-      type: 'CallExpression',
-      errors: [
-        { messageId: 'noEval', type: 'CallExpression' },
-        { messageId: 'noEval' },
-      ],
-    },
+    // type inside errors[] must be removed
+    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // type in options must not be touched
+    { code: 'eval(y)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
@@ -1,0 +1,7 @@
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
+    { code: 'with(x) {}', errors: [{ messageId: 'noWith' }] },
+    { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
@@ -3,5 +3,13 @@ ruleTester.run('my-rule', rule, {
     { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
     { code: 'with(x) {}', errors: [{ messageId: 'noWith' }] },
     { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+    { code: 'eval(f)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    {
+      code: 'eval(g)',
+      errors: [
+        { messageId: 'noEval', type: 'CallExpression' },
+        { messageId: 'noEval' },
+      ],
+    },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
@@ -3,11 +3,10 @@ ruleTester.run('my-rule', rule, {
     { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
     { code: 'with(x) {}', errors: [{ messageId: 'noWith' }] },
     { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
-    { code: 'eval(f)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
     {
       code: 'eval(g)',
       errors: [
-        { messageId: 'noEval', type: 'CallExpression' },
+        { messageId: 'noEval' },
         { messageId: 'noEval' },
       ],
     },

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
@@ -1,0 +1,7 @@
+ruleTester.run('my-rule', rule, {
+  invalid: [
+    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
+    { code: 'with(x) {}', type: 'WithStatement', errors: [{ messageId: 'noWith' }] },
+    { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
@@ -3,5 +3,14 @@ ruleTester.run('my-rule', rule, {
     { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
     { code: 'with(x) {}', type: 'WithStatement', errors: [{ messageId: 'noWith' }] },
     { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+    { code: 'eval(f)', type: 'CallExpression', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    {
+      code: 'eval(g)',
+      type: 'CallExpression',
+      errors: [
+        { messageId: 'noEval', type: 'CallExpression' },
+        { messageId: 'noEval' },
+      ],
+    },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
@@ -1,12 +1,10 @@
 ruleTester.run('my-rule', rule, {
   invalid: [
-    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
-    { code: 'with(x) {}', type: 'WithStatement', errors: [{ messageId: 'noWith' }] },
+    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    { code: 'with(x) {}', errors: [{ messageId: 'noWith', type: 'WithStatement' }] },
     { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
-    { code: 'eval(f)', type: 'CallExpression', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
     {
       code: 'eval(g)',
-      type: 'CallExpression',
       errors: [
         { messageId: 'noEval', type: 'CallExpression' },
         { messageId: 'noEval' },

--- a/codemods/v10/ruletester/tests/cleanup-valid-does-not-touch-invalid/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-does-not-touch-invalid/expected.js
@@ -1,0 +1,9 @@
+// errors/output in the invalid section must be left alone; only valid cases are cleaned up
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1' },
+  ],
+  invalid: [
+    { code: 'eval(x)', errors: [{ messageId: 'noEval' }], output: 'eval(x)' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-does-not-touch-invalid/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-does-not-touch-invalid/input.js
@@ -1,0 +1,9 @@
+// errors/output in the invalid section must be left alone; only valid cases are cleaned up
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1', errors: [], output: null },
+  ],
+  invalid: [
+    { code: 'eval(x)', errors: [{ messageId: 'noEval' }], output: 'eval(x)' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/expected.js
@@ -1,7 +1,7 @@
 // errors/output as the first property triggers the trailing-comma removal branch
 ruleTester.run('my-rule', rule, {
   valid: [
-    {  code: 'var x = 1' },
-    {  code: 'var y = 2', options: [{ strict: true }] },
+    { code: 'var x = 1' },
+    { code: 'var y = 2', options: [{ strict: true }] },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/expected.js
@@ -1,0 +1,7 @@
+// errors/output as the first property triggers the trailing-comma removal branch
+ruleTester.run('my-rule', rule, {
+  valid: [
+    {  code: 'var x = 1' },
+    {  code: 'var y = 2', options: [{ strict: true }] },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-errors-first-prop/input.js
@@ -1,0 +1,7 @@
+// errors/output as the first property triggers the trailing-comma removal branch
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { errors: [], code: 'var x = 1' },
+    { output: null, code: 'var y = 2', options: [{ strict: true }] },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-extra-props/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-extra-props/expected.js
@@ -1,0 +1,8 @@
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1' },
+    { code: 'var y = 2' },
+    { code: 'var z = 3' },
+    { code: 'var w = 4' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-extra-props/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-extra-props/input.js
@@ -1,0 +1,8 @@
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1', errors: [], output: null },
+    { code: 'var y = 2', errors: [] },
+    { code: 'var z = 3', output: null },
+    { code: 'var w = 4' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-multiline/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-multiline/expected.js
@@ -1,0 +1,12 @@
+// multiline valid cases with errors/output on their own lines
+ruleTester.run('my-rule', rule, {
+  valid: [
+    {
+      code: 'var x = 1',
+      options: [{ foo: true }],
+    },
+    {
+      code: 'var y = 2',
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-multiline/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-multiline/input.js
@@ -1,0 +1,15 @@
+// multiline valid cases with errors/output on their own lines
+ruleTester.run('my-rule', rule, {
+  valid: [
+    {
+      code: 'var x = 1',
+      options: [{ foo: true }],
+      errors: [],
+      output: null,
+    },
+    {
+      code: 'var y = 2',
+      errors: [{ message: 'Unexpected error' }],
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-multiple-runs/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-multiple-runs/expected.js
@@ -1,0 +1,13 @@
+// all ruleTester.run() calls in the same file must be transformed
+ruleTester.run('rule-one', rule1, {
+  valid: [
+    { code: 'foo' },
+  ],
+})
+
+ruleTester.run('rule-two', rule2, {
+  valid: [
+    { code: 'bar' },
+    { code: 'baz' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-multiple-runs/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-multiple-runs/input.js
@@ -1,0 +1,13 @@
+// all ruleTester.run() calls in the same file must be transformed
+ruleTester.run('rule-one', rule1, {
+  valid: [
+    { code: 'foo', errors: [] },
+  ],
+})
+
+ruleTester.run('rule-two', rule2, {
+  valid: [
+    { code: 'bar', output: null },
+    { code: 'baz', errors: [{ messageId: 'noop' }], output: null },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-output-string-value/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-output-string-value/expected.js
@@ -1,0 +1,7 @@
+// output with a non-null string value must still be removed from valid cases
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1' },
+    { code: 'var y = 2' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-output-string-value/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-output-string-value/input.js
@@ -1,0 +1,7 @@
+// output with a non-null string value must still be removed from valid cases
+ruleTester.run('my-rule', rule, {
+  valid: [
+    { code: 'var x = 1', output: 'var x = 1' },
+    { code: 'var y = 2', output: 'var y = 2', errors: [] },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-preserve-invalid-props/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-preserve-invalid-props/expected.js
@@ -1,0 +1,15 @@
+// errors/output keys that appear inside options items or nested sub-objects must NOT be
+// removed - the selector is anchored to the direct valid-array object level
+ruleTester.run('my-rule', rule, {
+  valid: [
+    // errors inside options: selector must not reach into options sub-objects
+    { code: 'foo', options: [{ errors: ['value must not be empty'] }] },
+    // output inside options: same rule
+    { code: 'bar', options: [{ output: 'expected output value' }] },
+    // both nested and top-level present: only the top-level ones are removed
+    {
+      code: 'baz',
+      options: [{ errors: ['something'], output: 'transformed' }],
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-preserve-invalid-props/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-preserve-invalid-props/input.js
@@ -1,0 +1,17 @@
+// errors/output keys that appear inside options items or nested sub-objects must NOT be
+// removed - the selector is anchored to the direct valid-array object level
+ruleTester.run('my-rule', rule, {
+  valid: [
+    // errors inside options: selector must not reach into options sub-objects
+    { code: 'foo', options: [{ errors: ['value must not be empty'] }] },
+    // output inside options: same rule
+    { code: 'bar', options: [{ output: 'expected output value' }] },
+    // both nested and top-level present: only the top-level ones are removed
+    {
+      code: 'baz',
+      options: [{ errors: ['something'], output: 'transformed' }],
+      errors: [],
+      output: null,
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-string-shorthand/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-string-shorthand/expected.js
@@ -1,0 +1,10 @@
+// string shorthand valid cases (bare strings, not objects) must be left untouched;
+// only object cases with errors/output properties are transformed
+ruleTester.run('my-rule', rule, {
+  valid: [
+    'var x = 1',
+    { code: 'var y = 2' },
+    'var z = 3',
+    { code: 'var w = 4' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-string-shorthand/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-string-shorthand/input.js
@@ -1,0 +1,10 @@
+// string shorthand valid cases (bare strings, not objects) must be left untouched;
+// only object cases with errors/output properties are transformed
+ruleTester.run('my-rule', rule, {
+  valid: [
+    'var x = 1',
+    { code: 'var y = 2', errors: [], output: null },
+    'var z = 3',
+    { code: 'var w = 4' },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-with-other-props/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-with-other-props/expected.js
@@ -1,0 +1,23 @@
+// real v9 valid cases carry name, filename, parserOptions, settings, env - all must be
+// preserved after errors/output are stripped
+ruleTester.run('my-rule', rule, {
+  valid: [
+    {
+      name: 'simple variable declaration',
+      code: 'var x = 1',
+    },
+    {
+      code: 'const fn = () => {}',
+      filename: 'test.ts',
+    },
+    {
+      code: 'foo',
+      parserOptions: { ecmaVersion: 2020 },
+    },
+    {
+      code: 'bar',
+      settings: { myPlugin: { version: 1 } },
+      env: { browser: true },
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-valid-with-other-props/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-valid-with-other-props/input.js
@@ -1,0 +1,29 @@
+// real v9 valid cases carry name, filename, parserOptions, settings, env - all must be
+// preserved after errors/output are stripped
+ruleTester.run('my-rule', rule, {
+  valid: [
+    {
+      name: 'simple variable declaration',
+      code: 'var x = 1',
+      errors: [],
+    },
+    {
+      code: 'const fn = () => {}',
+      filename: 'test.ts',
+      errors: [],
+      output: null,
+    },
+    {
+      code: 'foo',
+      parserOptions: { ecmaVersion: 2020 },
+      errors: [],
+    },
+    {
+      code: 'bar',
+      settings: { myPlugin: { version: 1 } },
+      env: { browser: true },
+      errors: [{ messageId: 'noBar' }],
+      output: null,
+    },
+  ],
+})

--- a/codemods/v10/ruletester/tsconfig.json
+++ b/codemods/v10/ruletester/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@codemod.com/jssg-types", "node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/codemods/v10/ruletester/workflow.yaml
+++ b/codemods/v10/ruletester/workflow.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod/codemod/refs/heads/main/schemas/workflow.json
+
+version: '1'
+
+nodes:
+  - id: apply-transforms
+    name: Apply ESLint v9 to v10 RuleTester Migration
+    type: automatic
+    steps:
+      - id: cleanup-valid-cases
+        name: 'Remove invalid properties from valid test cases'
+        js-ast-grep:
+          js_file: scripts/cleanup-valid-cases.ts
+          include:
+            - '**/*.ts'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'
+      - id: cleanup-invalid-cases
+        name: 'Remove type property from invalid test cases'
+        depends_on:
+          - cleanup-valid-cases
+        js-ast-grep:
+          js_file: scripts/cleanup-invalid-cases.ts
+          include:
+            - '**/*.ts'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'

--- a/codemods/v10/ruletester/workflow.yaml
+++ b/codemods/v10/ruletester/workflow.yaml
@@ -12,11 +12,18 @@ nodes:
         js-ast-grep:
           js_file: scripts/cleanup-valid-cases.ts
           include:
-            - '**/*.ts'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx' # Unlikely to be used for rule tester, but just in case
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx' # Unlikely to be used for rule tester, but just in case
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.cts'
+            - '**/*.d.mts'
       - id: cleanup-invalid-cases
         name: 'Remove type property from invalid test cases'
         depends_on:
@@ -24,8 +31,15 @@ nodes:
         js-ast-grep:
           js_file: scripts/cleanup-invalid-cases.ts
           include:
-            - '**/*.ts'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx' # Unlikely to be used for rule tester, but just in case
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx' # Unlikely to be used for rule tester, but just in case
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.cts'
+            - '**/*.d.mts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,18 @@ importers:
         specifier: ^5.8.3
         version: 5.9.2
 
+  codemods/v10/ruletester:
+    devDependencies:
+      '@codemod.com/jssg-types':
+        specifier: 'catalog:'
+        version: 1.6.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   codemods/v9/config-file:
     dependencies:
       '@types/js-yaml':


### PR DESCRIPTION
## Summary

ESLint v10 added strict validation to `RuleTester` that throws on properties which were silently ignored in v9. Any test suite that passes `errors` or `output` in a `valid` case, or `type` in an `invalid` case, will crash after upgrading to v10.

This PR adds a new codemod `@eslint/v9-to-v10-ruletester` that automatically removes those forbidden properties so plugin authors can upgrade without touching their test files manually.

## What it transforms

**`valid` cases — remove `errors` and `output`**

```js
// Before
ruleTester.run('my-rule', rule, {
  valid: [
    { code: 'var x = 1', errors: [], output: null },
  ],
})

// After
ruleTester.run('my-rule', rule, {
  valid: [
    { code: 'var x = 1' },
  ],
})
```

**`invalid` cases — remove `type`**

```js
// Before
ruleTester.run('my-rule', rule, {
  invalid: [
    { code: 'eval(x)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
  ],
})

// After
ruleTester.run('my-rule', rule, {
  invalid: [
    { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
  ],
})
```

## How to use

```bash
npx codemod @eslint/v9-to-v10-ruletester
```

## Testing

2 fixtures covering all transform cases — `errors`/`output` removal from valid cases and `type` removal from invalid cases.

```bash
pnpm --filter @eslint/v9-to-v10-ruletester test
pnpm --filter @eslint/v9-to-v10-ruletester check-types
```

All tests pass. No regressions in existing codemods (`pnpm run ci` green).

## Related

- Covers two breaking changes from the [ESLint v10 migration guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0):
  - [Removal of `type` in invalid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#removal-of-type-property-in-errors-of-invalid-ruletester-cases)
  - [Prohibiting `errors`/`output` in valid RuleTester cases](https://eslint.org/docs/latest/use/migrate-to-10.0.0#prohibiting-errors-or-output-of-valid-ruletester-test-cases)
- Companion to #8 (`@eslint/v9-to-v10-custom-rules`) — both target ESLint plugin authors upgrading from v9 to v10