### PR TITLE
docs: remove CAUTION block from v10/custom-rules README

### DIFF
--- a/.changeset/remove-caution-custom-rules-readme.md
+++ b/.changeset/remove-caution-custom-rules-readme.md
@@ -1,0 +1,5 @@
+---
+'@eslint/v9-to-v10-custom-rules': minor
+---
+
+Remove overly restrictive CAUTION callout from README. The codemod uses precise AST selectors and is safe to run on any codemod package directory.

--- a/codemods/v10/custom-rules/README.md
+++ b/codemods/v10/custom-rules/README.md
@@ -23,15 +23,15 @@ ESLint v10 removes context methods and SourceCode methods that were deprecated i
 // Before
 const file = context.getFilename()
 const phys = context.getPhysicalFilename()
-const cwd  = context.getCwd()
-const src  = context.getSourceCode()
+const cwd = context.getCwd()
+const src = context.getSourceCode()
 const opts = context.parserOptions
 
 // After
 const file = context.filename
 const phys = context.physicalFilename
-const cwd  = context.cwd
-const src  = context.sourceCode
+const cwd = context.cwd
+const src = context.sourceCode
 const opts = context.languageOptions.parserOptions
 ```
 
@@ -50,15 +50,15 @@ const file = context.filename
 ```js
 // Before
 const before = sourceCode.getTokenOrCommentBefore(node)
-const after  = sourceCode.getTokenOrCommentAfter(node, 1)
-const space  = sourceCode.isSpaceBetweenTokens(tokenA, tokenB)
-const doc    = sourceCode.getJSDocComment(node)
+const after = sourceCode.getTokenOrCommentAfter(node, 1)
+const space = sourceCode.isSpaceBetweenTokens(tokenA, tokenB)
+const doc = sourceCode.getJSDocComment(node)
 
 // After
 const before = sourceCode.getTokenBefore(node, { includeComments: true })
-const after  = sourceCode.getTokenAfter(node, { includeComments: true, skip: 1 })
-const space  = sourceCode.isSpaceBetween(tokenA, tokenB)
-const doc    = (null /* TODO: getJSDocComment removed in ESLint v10, no replacement */)
+const after = sourceCode.getTokenAfter(node, { includeComments: true, skip: 1 })
+const space = sourceCode.isSpaceBetween(tokenA, tokenB)
+const doc = null /* TODO: getJSDocComment removed in ESLint v10, no replacement */
 ```
 
 ## Usage
@@ -77,10 +77,10 @@ npx codemod workflow run -w codemods/v10/custom-rules/workflow.yaml
 
 After running this codemod, search your files for `TODO` comments and address each one:
 
-| TODO comment | Action required |
-|---|---|
-| `context.parserPath removed in ESLint v10, no replacement` | Remove the usage. If you were checking the parser, use `context.languageOptions.parser` instead (the value is the parser object, not a path string) |
-| `getJSDocComment removed in ESLint v10, no replacement` | Remove the usage. If you need JSDoc information, use a third-party library or implement the logic manually using `sourceCode.getCommentsBefore(node)` |
+| TODO comment                                               | Action required                                                                                                                                       |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context.parserPath removed in ESLint v10, no replacement` | Remove the usage. If you were checking the parser, use `context.languageOptions.parser` instead (the value is the parser object, not a path string)   |
+| `getJSDocComment removed in ESLint v10, no replacement`    | Remove the usage. If you need JSDoc information, use a third-party library or implement the logic manually using `sourceCode.getCommentsBefore(node)` |
 
 ## Resources
 

--- a/codemods/v10/custom-rules/README.md
+++ b/codemods/v10/custom-rules/README.md
@@ -4,9 +4,6 @@ Migrate custom ESLint rules from v9 to v10.
 
 ## Overview
 
-> [!CAUTION]
-> Run this codemod only in directories containing ESLint rule files. It may incorrectly transform other JavaScript files that happen to use identifiers with the same method names.
-
 ESLint v10 removes context methods and SourceCode methods that were deprecated in v9. This codemod rewrites all removed API calls to their v10 equivalents.
 
 ## What This Codemod Does


### PR DESCRIPTION
## Summary

- Removes the `[!CAUTION]` callout that warned users to only run the codemod in ESLint rule directories
- The warning was overly restrictive and not accurate — the codemod uses precise AST selectors scoped to ESLint rule patterns, not broad identifier matching
