### PR TITLE
feat: add @eslint/v9-to-v10-linter-api codemod

### DIFF
--- a/.changeset/v9-to-v10-linter-api.md
+++ b/.changeset/v9-to-v10-linter-api.md
@@ -2,4 +2,4 @@
 '@eslint/v9-to-v10-linter-api': minor
 ---
 
-Add new codemod to migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10. Handles configType removal, useFlatConfig removal, FlatESLint rename, LegacyESLint removal, deprecated Linter methods, func-names schema tightening, and no-invalid-regexp duplicate flag deduplication.
+Add new codemod to migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10. Handles configType removal from new Linter(), useFlatConfig removal from loadESLint(), deprecated flag value removal from new ESLint({ flags }), deprecated Linter instance methods, func-names schema tightening, no-invalid-regexp duplicate flag deduplication, and radix deprecated option removal.

--- a/.changeset/v9-to-v10-linter-api.md
+++ b/.changeset/v9-to-v10-linter-api.md
@@ -1,0 +1,5 @@
+---
+'@eslint/v9-to-v10-linter-api': minor
+---
+
+Add new codemod to migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10. Handles configType removal, useFlatConfig removal, FlatESLint rename, LegacyESLint removal, deprecated Linter methods, func-names schema tightening, and no-invalid-regexp duplicate flag deduplication.

--- a/.changeset/v9-to-v10-linter-api.md
+++ b/.changeset/v9-to-v10-linter-api.md
@@ -2,4 +2,4 @@
 '@eslint/v9-to-v10-linter-api': minor
 ---
 
-Add new codemod to migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10. Handles configType removal from new Linter(), useFlatConfig removal from loadESLint(), deprecated flag value removal from new ESLint({ flags }), deprecated Linter instance methods, func-names schema tightening, no-invalid-regexp duplicate flag deduplication, and radix deprecated option removal.
+Add new codemod to migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10. Handles configType removal from new Linter(), useFlatConfig removal from loadESLint(), deprecated flag value removal from new ESLint({ flags }), deprecated Linter instance methods, func-names schema tightening, no-invalid-regexp duplicate flag deduplication, radix deprecated option removal, and LintMessage.nodeType object property removal.

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,4 +1,5 @@
 const LOCKFILE_SUFFIXES = ['pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json']
+const TEST_DIR_RE = /[/\\]tests[/\\]/
 
 /** @param {string[]} files */
 function excludeLockfiles(files) {
@@ -7,11 +8,17 @@ function excludeLockfiles(files) {
 
 export default {
   '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'oxfmt --write',
-  '*.{js,mjs,cjs,jsx}': 'oxlint --fix',
+  // oxlint ignorePatterns excludes **/tests — skip test fixtures upfront to avoid "no files" error
+  /** @param {string[]} files */
+  '*.{js,mjs,cjs,jsx}': (files) => {
+    const toCheck = files.filter((f) => !TEST_DIR_RE.test(f))
+    return toCheck.length ? [`oxlint --fix ${toCheck.join(' ')}`] : []
+  },
   '*.{ts,mts,cts,tsx}': 'oxlint --type-aware --type-check --fix',
   /** @param {string[]} files */
   '*.{json,yaml,yml}': (files) => {
-    const filtered = excludeLockfiles(files)
+    // oxfmt errors when all files are excluded by ignorePatterns; skip test fixtures upfront
+    const filtered = excludeLockfiles(files).filter((f) => !TEST_DIR_RE.test(f))
     return filtered.length ? [`oxfmt --write ${filtered.join(' ')}`] : []
   },
   'codemods/**/scripts/**/*.ts': ["bash -c 'pnpm run test'"],

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,4 @@
 const LOCKFILE_SUFFIXES = ['pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json']
-const TEST_DIR_RE = /[/\\]tests[/\\]/
 
 /** @param {string[]} files */
 function excludeLockfiles(files) {

--- a/codemods/v10/linter-api/README.md
+++ b/codemods/v10/linter-api/README.md
@@ -1,0 +1,148 @@
+# @eslint/v9-to-v10-linter-api
+
+Migrate removed `Linter`/`ESLint` constructor options and stricter rule config schema for ESLint v10.
+
+## Overview
+
+ESLint v10 removes the `configType` option, the `useFlatConfig` option on `loadESLint`, the `FlatESLint` and `LegacyESLint` class aliases, several `Linter` instance methods, and tightens the schema for two built-in rules.
+
+## What This Codemod Does
+
+### Transform 1 — Remove `configType` from `new Linter()` / `new ESLint()`
+
+`configType: 'flat'` is the only supported mode in v10 and no longer needs to be specified. `configType: 'eslintrc'` is removed with no equivalent — a TODO comment is inserted.
+
+```js
+// Before
+const linter = new Linter({ configType: 'flat' })
+const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
+const legacy = new Linter({ configType: 'eslintrc' })
+
+// After
+const linter = new Linter()
+const linter2 = new Linter({ allowInlineConfig: true })
+const legacy = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+```
+
+### Transform 2 — Remove `useFlatConfig` from `loadESLint()`
+
+```js
+// Before
+const ESLintClass = await loadESLint({ useFlatConfig: true })
+
+// After
+const ESLintClass = await loadESLint()
+```
+
+### Transform 3 — Remove `v10_config_lookup_from_file` from `ESLint` flags
+
+```js
+// Before
+const eslint = new ESLint({ flags: ['v10_config_lookup_from_file'] })
+
+// After
+const eslint = new ESLint({ flags: [] })
+```
+
+### Transform 4 — `FlatESLint` → `ESLint` (class renamed)
+
+```js
+// Before
+import { FlatESLint } from 'eslint'
+const eslint = new FlatESLint({ fix: true })
+
+// After
+import { ESLint } from 'eslint'
+const eslint = new ESLint({ fix: true })
+```
+
+### Transform 5 — `LegacyESLint` → TODO (class removed)
+
+```js
+// Before
+import { LegacyESLint } from 'eslint'
+
+// After
+import { LegacyESLint /* TODO: LegacyESLint removed in ESLint v10, no replacement — rewrite to use flat config */ } from 'eslint'
+```
+
+### Transform 6 — Deprecated `Linter` instance methods → TODO
+
+`defineParser()`, `defineRule()`, `defineRules()`, and `getRules()` are removed with no direct replacement. Register rules and parsers via the flat config instead.
+
+```js
+// Before
+linter.defineParser('babel-eslint', require('babel-eslint'))
+linter.defineRule('my-rule', myRule)
+
+// After
+linter.defineParser(/* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint', require('babel-eslint'))
+linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
+```
+
+### Transform 7 — `func-names` stricter schema (remove extra 4th element)
+
+```js
+// Before
+'func-names': ['error', 'always', {}, 'as-needed']
+
+// After
+'func-names': ['error', 'always', {}]
+```
+
+### Transform 8 — `no-invalid-regexp` deduplicate `allowConstructorFlags`
+
+```js
+// Before
+'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y', 'u'] }]
+
+// After
+'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }]
+```
+
+### Transform 9 — `radix` deprecated string options
+
+The `"always"` and `"as-needed"` string options of the `radix` rule are deprecated in ESLint v10. The rule now always enforces providing a radix argument. `"always"` is stripped (it is now the sole behavior). `"as-needed"` is flagged with a TODO because removing it changes the rule's behavior.
+
+```js
+// Before
+'radix': ['error', 'always']
+'radix': ['error', 'as-needed']
+
+// After
+'radix': 'error'
+'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed']
+```
+
+## Usage
+
+```bash
+npx codemod @eslint/v9-to-v10-linter-api
+```
+
+## After running
+
+Search for `TODO` comments added by this codemod:
+
+| TODO comment | Action required |
+| ----------------------------------------------------------- | --------------------------------------------------------------- |
+| `configType "eslintrc" is removed` | Rewrite integration to use flat config (`eslint.config.js`) |
+| `LegacyESLint removed in ESLint v10` | Rewrite integration to use the `ESLint` class with flat config |
+| `defineParser() removed in ESLint v10` | Register parsers in `eslint.config.js` `languageOptions.parser` |
+| `defineRule() removed in ESLint v10` | Register rules in `eslint.config.js` `plugins` |
+| `defineRules() removed in ESLint v10` | Register rules in `eslint.config.js` `plugins` |
+| `getRules() removed in ESLint v10` | Use `ESLint.getRulesMetaForResults()` or `Linter.getRules()` was removed with no equivalent |
+
+## Limitations
+
+- `LintMessage.nodeType` access is not transformed — remove manually if you read `message.nodeType` in formatters or custom tooling.
+- `FlatESLint` and `LegacyESLint` occurrences inside string literals and comments are also renamed/flagged (acceptable trade-off of raw-text transform).
+- Fixer non-string argument validation is not automatable — check manually if you call `fixer.insertTextBefore(node, nonString)`.
+- `loadESLint({ useFlatConfig: true/false, ...otherOptions })` is **not** transformed when extra options are present alongside `useFlatConfig` — remove `useFlatConfig` manually in those cases.
+- `new Linter({ configType: 'eslintrc', ...otherOptions })` is **not** flagged with a TODO when additional options are present — add the TODO comment manually.
+- `func-names` options with nested objects (e.g. `{ generators: { mode: 'strict' } }`) are **not** transformed — the regex only matches flat (non-nested) options objects.
+- `radix` rule with `"always"` is only stripped when it is the sole option in the array (e.g. `['error', 'always']`); forms with additional elements are left untouched.
+
+## Resources
+
+- [ESLint v10 Migration Guide](https://eslint.org/docs/latest/use/migrate-to-10.0.0)

--- a/codemods/v10/linter-api/README.md
+++ b/codemods/v10/linter-api/README.md
@@ -12,88 +12,67 @@ ESLint v10 removes the `configType` option, the `useFlatConfig` option on `loadE
 
 `configType: 'flat'` is the only supported mode in v10 and no longer needs to be specified. `configType: 'eslintrc'` is removed with no equivalent — a TODO comment is inserted.
 
-```js
-// Before
-const linter = new Linter({ configType: 'flat' })
-const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
-const legacy = new Linter({ configType: 'eslintrc' })
-
-// After
-const linter = new Linter()
-const linter2 = new Linter({ allowInlineConfig: true })
-const legacy =
-  new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+```diff
+-const linter = new Linter({ configType: 'flat' })
+-const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
+-const legacy = new Linter({ configType: 'eslintrc' })
++const linter = new Linter()
++const linter2 = new Linter({ allowInlineConfig: true })
++const legacy =
++  new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
 ```
 
 ### Transform 2 — Remove `useFlatConfig` from `loadESLint()`
 
-```js
-// Before
-const ESLintClass = await loadESLint({ useFlatConfig: true })
-
-// After
-const ESLintClass = await loadESLint()
+```diff
+-const ESLintClass = await loadESLint({ useFlatConfig: true })
++const ESLintClass = await loadESLint()
 ```
 
 ### Transform 3 — Remove deprecated flag values from `new ESLint({ flags: [...] })`
 
-```js
-// Before
-const eslint = new ESLint({ flags: ['v10_config_lookup_from_file'] })
-
-// After
-const eslint = new ESLint({ flags: [] })
+```diff
+-const eslint = new ESLint({ flags: ['v10_config_lookup_from_file'] })
++const eslint = new ESLint({ flags: [] })
 ```
 
 ### Transform 4 — Deprecated `Linter` instance methods → TODO
 
 `defineParser()`, `defineRule()`, `defineRules()`, and `getRules()` are removed with no direct replacement. Register rules and parsers via the flat config instead.
 
-```js
-// Before
-linter.defineParser('babel-eslint', require('babel-eslint'))
-linter.defineRule('my-rule', myRule)
-
-// After
-linter.defineParser(
-  /* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint',
-  require('babel-eslint'),
-)
-linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
+```diff
+-linter.defineParser('babel-eslint', require('babel-eslint'))
+-linter.defineRule('my-rule', myRule)
++linter.defineParser(
++  /* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint',
++  require('babel-eslint'),
++)
++linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
 ```
 
 ### Transform 5 — `func-names` stricter schema (remove extra 4th element)
 
-```js
-// Before
-'func-names': ['error', 'always', {}, 'as-needed']
-
-// After
-'func-names': ['error', 'always', {}]
+```diff
+-'func-names': ['error', 'always', {}, 'as-needed']
++'func-names': ['error', 'always', {}]
 ```
 
 ### Transform 6 — `no-invalid-regexp` deduplicate `allowConstructorFlags`
 
-```js
-// Before
-'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y', 'u'] }]
-
-// After
-'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }]
+```diff
+-'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y', 'u'] }]
++'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }]
 ```
 
 ### Transform 7 — `radix` deprecated string options
 
 The `"always"` and `"as-needed"` string options of the `radix` rule are deprecated in ESLint v10. The rule now always enforces providing a radix argument. `"always"` is stripped (it is now the sole behavior). `"as-needed"` is flagged with a TODO because removing it changes the rule's behavior.
 
-```js
-// Before
-'radix': ['error', 'always']
-'radix': ['error', 'as-needed']
-
-// After
-'radix': 'error'
-'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed']
+```diff
+-'radix': ['error', 'always']
+-'radix': ['error', 'as-needed']
++'radix': 'error'
++'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed']
 ```
 
 ### Transform 8 — Remove `LintMessage.nodeType`
@@ -102,31 +81,20 @@ The `"always"` and `"as-needed"` string options of the `radix` rule are deprecat
 
 **Object property pairs** — `nodeType: <value>` is removed from object literals (common in test assertions):
 
-```js
-// Before
-assert.deepEqual(messages[0], {
-  ruleId: 'no-var',
-  severity: 2,
-  message: 'Unexpected var, use let or const instead.',
-  nodeType: 'VariableDeclaration',
-})
-
-// After
-assert.deepEqual(messages[0], {
-  ruleId: 'no-var',
-  severity: 2,
-  message: 'Unexpected var, use let or const instead.',
-})
+```diff
+ assert.deepEqual(messages[0], {
+   ruleId: 'no-var',
+   severity: 2,
+   message: 'Unexpected var, use let or const instead.',
+-  nodeType: 'VariableDeclaration',
+ })
 ```
 
 **Member expression accesses** — `.nodeType` in formatters and custom tooling is flagged with a TODO (the surrounding expression must be removed manually):
 
-```js
-// Before
-const type = message.nodeType
-
-// After
-const type = message.nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */
+```diff
+-const type = message.nodeType
++const type = message.nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */
 ```
 
 ## Usage

--- a/codemods/v10/linter-api/README.md
+++ b/codemods/v10/linter-api/README.md
@@ -4,11 +4,11 @@ Migrate removed `Linter`/`ESLint` constructor options and stricter rule config s
 
 ## Overview
 
-ESLint v10 removes the `configType` option, the `useFlatConfig` option on `loadESLint`, the `FlatESLint` and `LegacyESLint` class aliases, several `Linter` instance methods, and tightens the schema for two built-in rules.
+ESLint v10 removes the `configType` option, the `useFlatConfig` option on `loadESLint`, several `Linter` instance methods, and tightens the schema for three built-in rules.
 
 ## What This Codemod Does
 
-### Transform 1 — Remove `configType` from `new Linter()` / `new ESLint()`
+### Transform 1 — Remove `configType` from `new Linter()`
 
 `configType: 'flat'` is the only supported mode in v10 and no longer needs to be specified. `configType: 'eslintrc'` is removed with no equivalent — a TODO comment is inserted.
 
@@ -35,7 +35,7 @@ const ESLintClass = await loadESLint({ useFlatConfig: true })
 const ESLintClass = await loadESLint()
 ```
 
-### Transform 3 — Remove `v10_config_lookup_from_file` from `ESLint` flags
+### Transform 3 — Remove deprecated flag values from `new ESLint({ flags: [...] })`
 
 ```js
 // Before
@@ -45,31 +45,7 @@ const eslint = new ESLint({ flags: ['v10_config_lookup_from_file'] })
 const eslint = new ESLint({ flags: [] })
 ```
 
-### Transform 4 — `FlatESLint` → `ESLint` (class renamed)
-
-```js
-// Before
-import { FlatESLint } from 'eslint'
-const eslint = new FlatESLint({ fix: true })
-
-// After
-import { ESLint } from 'eslint'
-const eslint = new ESLint({ fix: true })
-```
-
-### Transform 5 — `LegacyESLint` → TODO (class removed)
-
-```js
-// Before
-import { LegacyESLint } from 'eslint'
-
-// After
-import {
-  LegacyESLint /* TODO: LegacyESLint removed in ESLint v10, no replacement — rewrite to use flat config */,
-} from 'eslint'
-```
-
-### Transform 6 — Deprecated `Linter` instance methods → TODO
+### Transform 4 — Deprecated `Linter` instance methods → TODO
 
 `defineParser()`, `defineRule()`, `defineRules()`, and `getRules()` are removed with no direct replacement. Register rules and parsers via the flat config instead.
 
@@ -86,7 +62,7 @@ linter.defineParser(
 linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
 ```
 
-### Transform 7 — `func-names` stricter schema (remove extra 4th element)
+### Transform 5 — `func-names` stricter schema (remove extra 4th element)
 
 ```js
 // Before
@@ -96,7 +72,7 @@ linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */
 'func-names': ['error', 'always', {}]
 ```
 
-### Transform 8 — `no-invalid-regexp` deduplicate `allowConstructorFlags`
+### Transform 6 — `no-invalid-regexp` deduplicate `allowConstructorFlags`
 
 ```js
 // Before
@@ -106,7 +82,7 @@ linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */
 'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }]
 ```
 
-### Transform 9 — `radix` deprecated string options
+### Transform 7 — `radix` deprecated string options
 
 The `"always"` and `"as-needed"` string options of the `radix` rule are deprecated in ESLint v10. The rule now always enforces providing a radix argument. `"always"` is stripped (it is now the sole behavior). `"as-needed"` is flagged with a TODO because removing it changes the rule's behavior.
 
@@ -133,7 +109,6 @@ Search for `TODO` comments added by this codemod:
 | TODO comment                           | Action required                                                                             |
 | -------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `configType "eslintrc" is removed`     | Rewrite integration to use flat config (`eslint.config.js`)                                 |
-| `LegacyESLint removed in ESLint v10`   | Rewrite integration to use the `ESLint` class with flat config                              |
 | `defineParser() removed in ESLint v10` | Register parsers in `eslint.config.js` `languageOptions.parser`                             |
 | `defineRule() removed in ESLint v10`   | Register rules in `eslint.config.js` `plugins`                                              |
 | `defineRules() removed in ESLint v10`  | Register rules in `eslint.config.js` `plugins`                                              |
@@ -142,7 +117,6 @@ Search for `TODO` comments added by this codemod:
 ## Limitations
 
 - `LintMessage.nodeType` access is not transformed — remove manually if you read `message.nodeType` in formatters or custom tooling.
-- `FlatESLint` and `LegacyESLint` occurrences inside string literals and comments are also renamed/flagged (acceptable trade-off of raw-text transform).
 - Fixer non-string argument validation is not automatable — check manually if you call `fixer.insertTextBefore(node, nonString)`.
 - `loadESLint({ useFlatConfig: true/false, ...otherOptions })` is **not** transformed when extra options are present alongside `useFlatConfig` — remove `useFlatConfig` manually in those cases.
 - `new Linter({ configType: 'eslintrc', ...otherOptions })` is **not** flagged with a TODO when additional options are present — add the TODO comment manually.

--- a/codemods/v10/linter-api/README.md
+++ b/codemods/v10/linter-api/README.md
@@ -96,6 +96,39 @@ The `"always"` and `"as-needed"` string options of the `radix` rule are deprecat
 'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed']
 ```
 
+### Transform 8 — Remove `LintMessage.nodeType`
+
+`LintMessage.nodeType` was removed in ESLint v10. Two patterns are handled:
+
+**Object property pairs** — `nodeType: <value>` is removed from object literals (common in test assertions):
+
+```js
+// Before
+assert.deepEqual(messages[0], {
+  ruleId: 'no-var',
+  severity: 2,
+  message: 'Unexpected var, use let or const instead.',
+  nodeType: 'VariableDeclaration',
+})
+
+// After
+assert.deepEqual(messages[0], {
+  ruleId: 'no-var',
+  severity: 2,
+  message: 'Unexpected var, use let or const instead.',
+})
+```
+
+**Member expression accesses** — `.nodeType` in formatters and custom tooling is flagged with a TODO (the surrounding expression must be removed manually):
+
+```js
+// Before
+const type = message.nodeType
+
+// After
+const type = message.nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */
+```
+
 ## Usage
 
 ```bash
@@ -113,10 +146,11 @@ Search for `TODO` comments added by this codemod:
 | `defineRule() removed in ESLint v10`   | Register rules in `eslint.config.js` `plugins`                                              |
 | `defineRules() removed in ESLint v10`  | Register rules in `eslint.config.js` `plugins`                                              |
 | `getRules() removed in ESLint v10`     | Use `ESLint.getRulesMetaForResults()` or `Linter.getRules()` was removed with no equivalent |
+| `LintMessage.nodeType was removed`     | Remove the surrounding expression that reads `message.nodeType`                             |
 
 ## Limitations
 
-- `LintMessage.nodeType` access is not transformed — remove manually if you read `message.nodeType` in formatters or custom tooling.
+- `message.nodeType` member expression accesses are flagged with a TODO but the surrounding expression must be removed manually — the codemod cannot determine what to replace the access with.
 - Fixer non-string argument validation is not automatable — check manually if you call `fixer.insertTextBefore(node, nonString)`.
 - `loadESLint({ useFlatConfig: true/false, ...otherOptions })` is **not** transformed when extra options are present alongside `useFlatConfig` — remove `useFlatConfig` manually in those cases.
 - `new Linter({ configType: 'eslintrc', ...otherOptions })` is **not** flagged with a TODO when additional options are present — add the TODO comment manually.

--- a/codemods/v10/linter-api/README.md
+++ b/codemods/v10/linter-api/README.md
@@ -21,7 +21,8 @@ const legacy = new Linter({ configType: 'eslintrc' })
 // After
 const linter = new Linter()
 const linter2 = new Linter({ allowInlineConfig: true })
-const legacy = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+const legacy =
+  new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
 ```
 
 ### Transform 2 — Remove `useFlatConfig` from `loadESLint()`
@@ -63,7 +64,9 @@ const eslint = new ESLint({ fix: true })
 import { LegacyESLint } from 'eslint'
 
 // After
-import { LegacyESLint /* TODO: LegacyESLint removed in ESLint v10, no replacement — rewrite to use flat config */ } from 'eslint'
+import {
+  LegacyESLint /* TODO: LegacyESLint removed in ESLint v10, no replacement — rewrite to use flat config */,
+} from 'eslint'
 ```
 
 ### Transform 6 — Deprecated `Linter` instance methods → TODO
@@ -76,7 +79,10 @@ linter.defineParser('babel-eslint', require('babel-eslint'))
 linter.defineRule('my-rule', myRule)
 
 // After
-linter.defineParser(/* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint', require('babel-eslint'))
+linter.defineParser(
+  /* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint',
+  require('babel-eslint'),
+)
 linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
 ```
 
@@ -124,14 +130,14 @@ npx codemod @eslint/v9-to-v10-linter-api
 
 Search for `TODO` comments added by this codemod:
 
-| TODO comment | Action required |
-| ----------------------------------------------------------- | --------------------------------------------------------------- |
-| `configType "eslintrc" is removed` | Rewrite integration to use flat config (`eslint.config.js`) |
-| `LegacyESLint removed in ESLint v10` | Rewrite integration to use the `ESLint` class with flat config |
-| `defineParser() removed in ESLint v10` | Register parsers in `eslint.config.js` `languageOptions.parser` |
-| `defineRule() removed in ESLint v10` | Register rules in `eslint.config.js` `plugins` |
-| `defineRules() removed in ESLint v10` | Register rules in `eslint.config.js` `plugins` |
-| `getRules() removed in ESLint v10` | Use `ESLint.getRulesMetaForResults()` or `Linter.getRules()` was removed with no equivalent |
+| TODO comment                           | Action required                                                                             |
+| -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `configType "eslintrc" is removed`     | Rewrite integration to use flat config (`eslint.config.js`)                                 |
+| `LegacyESLint removed in ESLint v10`   | Rewrite integration to use the `ESLint` class with flat config                              |
+| `defineParser() removed in ESLint v10` | Register parsers in `eslint.config.js` `languageOptions.parser`                             |
+| `defineRule() removed in ESLint v10`   | Register rules in `eslint.config.js` `plugins`                                              |
+| `defineRules() removed in ESLint v10`  | Register rules in `eslint.config.js` `plugins`                                              |
+| `getRules() removed in ESLint v10`     | Use `ESLint.getRulesMetaForResults()` or `Linter.getRules()` was removed with no equivalent |
 
 ## Limitations
 

--- a/codemods/v10/linter-api/codemod.yaml
+++ b/codemods/v10/linter-api/codemod.yaml
@@ -1,0 +1,20 @@
+schema_version: '1.0'
+
+name: '@eslint/v9-to-v10-linter-api'
+version: '1.0.0'
+description: 'Migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10'
+author: 'Rohit Khadatkar <khadatkarrohit@gmail.com>'
+license: 'MIT'
+workflow: 'workflow.yaml'
+repository: 'https://github.com/eslint/codemods'
+
+targets:
+  languages: ['typescript', 'javascript']
+
+keywords: ['transformation', 'migration', 'eslint', 'v9', 'v10']
+
+registry:
+  access: 'public'
+  visibility: 'public'
+
+capabilities: []

--- a/codemods/v10/linter-api/codemod.yaml
+++ b/codemods/v10/linter-api/codemod.yaml
@@ -16,5 +16,3 @@ keywords: ['transformation', 'migration', 'eslint', 'v9', 'v10']
 registry:
   access: 'public'
   visibility: 'public'
-
-capabilities: []

--- a/codemods/v10/linter-api/package.json
+++ b/codemods/v10/linter-api/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc --noEmit",
-    "test": "pnpm run test:linter-constructor && pnpm run test:rule-options",
+    "test": "pnpm run test:linter-constructor && pnpm run test:rule-options && pnpm run test:lint-message",
     "test:linter-constructor": "codemod jssg test -l javascript ./scripts/fix-linter-constructor.ts --filter linter-constructor",
-    "test:rule-options": "codemod jssg test -l javascript ./scripts/fix-rule-options.ts --filter rule-options"
+    "test:rule-options": "codemod jssg test -l javascript ./scripts/fix-rule-options.ts --filter rule-options",
+    "test:lint-message": "codemod jssg test -l javascript ./scripts/fix-lint-message.ts --filter lint-message"
   },
   "devDependencies": {
     "@codemod.com/jssg-types": "catalog:",

--- a/codemods/v10/linter-api/package.json
+++ b/codemods/v10/linter-api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@eslint/v9-to-v10-linter-api",
+  "version": "1.0.0",
+  "description": "Migrate removed Linter/ESLint constructor options and stricter rule config schema for ESLint v10",
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "pnpm run test:linter-constructor && pnpm run test:rule-options",
+    "test:linter-constructor": "codemod jssg test -l javascript ./scripts/fix-linter-constructor.ts --filter linter-constructor",
+    "test:rule-options": "codemod jssg test -l javascript ./scripts/fix-rule-options.ts --filter rule-options"
+  },
+  "devDependencies": {
+    "@codemod.com/jssg-types": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/codemods/v10/linter-api/scripts/fix-lint-message.ts
+++ b/codemods/v10/linter-api/scripts/fix-lint-message.ts
@@ -1,18 +1,10 @@
-import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import type { Edit, SgNode, SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 // LintMessage.nodeType was removed in ESLint v10.
-// 1. Remove `nodeType: <value>` property pairs from object literals.
+// 1. Remove `nodeType: <value>` property pairs from object literals that can be
+//    resolved as LintMessage objects (from eslint's verify/verifyAndFix).
 // 2. Flag `.nodeType` member expression accesses with a TODO comment.
-const selector = {
-  rule: {
-    kind: 'pair',
-    has: {
-      kind: 'property_identifier',
-      regex: '^nodeType$',
-    },
-  },
-} as const satisfies RuleConfig<JS>
 
 function removePairEdit(pair: SgNode<JS>, source: string): Edit {
   const range = pair.range()
@@ -52,14 +44,104 @@ function removePairEdit(pair: SgNode<JS>, source: string): Edit {
   }
 }
 
+// Check whether a `nodeType` pair lives inside an object that can be identified
+// as an ESLint LintMessage via:
+//  1. Sibling LintMessage properties in the same object (fast path, no semantic needed)
+//  2. definition() resolution of a sibling call argument to verify/verifyAndFix
+//  3. Subscript-expression heuristic (fallback when semantic provider is unavailable)
+function isInLintMessageContext(pair: SgNode<JS>): boolean {
+  const parentObj = pair.parent()
+  if (parentObj?.kind() !== 'object') return false
+
+  // ── Check 1: parent object has a sibling property that only LintMessage carries ──
+  if (
+    parentObj.find({
+      rule: {
+        kind: 'pair',
+        has: {
+          field: 'key',
+          regex: 'ruleId|message|line|column|endLine|endColumn|fix|suggestions|source',
+        },
+      },
+    })
+  )
+    return true
+
+  // ── Check 2 & 3: resolve via the containing call expression ──────────────────
+  // Walk up through any intermediate array wrapper to reach the `arguments` node
+  let argNode: SgNode<JS> = parentObj
+  let cursor: SgNode<JS> | null = parentObj.parent()
+  while (cursor?.kind() === 'array') {
+    argNode = cursor
+    cursor = cursor.parent()
+  }
+  if (cursor?.kind() !== 'arguments') return false
+
+  for (const sibling of cursor.children()) {
+    if (!sibling.isNamed() || sibling.id() === argNode.id()) continue
+
+    // Check 2: try definition() to trace the sibling back to verify/verifyAndFix
+    for (const id of [sibling, ...sibling.findAll({ rule: { kind: 'identifier' } })]) {
+      if (id.kind() !== 'identifier') continue
+      // Guard: definition() requires a semantic provider — not always available
+      if (typeof id.definition !== 'function') break
+
+      const def = id.definition({ resolveExternal: false })
+      if (def?.kind !== 'local') continue
+
+      const declarator = def.node.parent()
+      if (declarator?.kind() !== 'variable_declarator') continue
+
+      if (
+        declarator.find({
+          rule: {
+            kind: 'call_expression',
+            has: {
+              field: 'function',
+              has: { kind: 'property_identifier', regex: '^verify(AndFix)?$' },
+            },
+          },
+        })
+      )
+        return true
+    }
+
+    // Check 3: fallback — sibling is or contains a subscript_expression (messages[N])
+    // Combined with the file-level eslint import guard this is a strong enough signal
+    if (sibling.kind() === 'subscript_expression' || sibling.find({ rule: { kind: 'subscript_expression' } }))
+      return true
+  }
+
+  return false
+}
+
 // .nodeType member access on any object — flag with TODO for manual removal
 const NODETYPE_MEMBER_RE = /\.nodeType\b/g
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
   const rootNode = root.root()
-  const pairs = rootNode.findAll(selector)
-
   const source = rootNode.text()
+
+  // Guard: only process files that import from eslint to avoid touching unrelated
+  // objects that happen to have a nodeType property
+  const hasEslintImport =
+    /from\s+['"]eslint['"]/m.test(source) ||
+    /require\s*\(\s*['"]eslint['"]\s*\)/m.test(source) ||
+    /import\s*\(\s*['"]eslint['"]\s*\)/m.test(source)
+  if (!hasEslintImport) return null
+
+  const allPairs = rootNode.findAll({
+    rule: {
+      kind: 'pair',
+      has: {
+        kind: 'property_identifier',
+        regex: '^nodeType$',
+      },
+    },
+  })
+
+  // Keep only pairs whose parent object can be identified as a LintMessage
+  const pairs = allPairs.filter(isInLintMessageContext)
 
   // 1. Remove nodeType: <value> object property pairs
   let result = pairs.length > 0 ? rootNode.commitEdits(pairs.map((pair) => removePairEdit(pair, source))) : source

--- a/codemods/v10/linter-api/scripts/fix-lint-message.ts
+++ b/codemods/v10/linter-api/scripts/fix-lint-message.ts
@@ -23,15 +23,13 @@ function removePairEdit(pair: SgNode<JS>, source: string): Edit {
     }
   }
 
-  // First property — remove trailing comma and the leading newline+indent to avoid a blank line
+  // First property — remove trailing comma (and any whitespace after it)
   const after = source.slice(end)
-  const trailingComma = after.match(/^\s*,/)
+  const trailingComma = after.match(/^\s*,\s*/)
 
   if (trailingComma) {
-    const leadingNewlineAndIndent = before.match(/\n[ \t]*$/)
-    const adjustedStart = leadingNewlineAndIndent ? start - leadingNewlineAndIndent[0].length : start
     return {
-      startPos: adjustedStart,
+      startPos: start,
       endPos: end + trailingComma[0].length,
       insertedText: '',
     }
@@ -75,14 +73,14 @@ function isInLintMessageContext(pair: SgNode<JS>): boolean {
     argNode = cursor
     cursor = cursor.parent()
   }
-  if (cursor?.kind() !== 'arguments') return false
+  if (!cursor?.is('arguments')) return false
 
   for (const sibling of cursor.children()) {
     if (!sibling.isNamed() || sibling.id() === argNode.id()) continue
 
     // Check 2: try definition() to trace the sibling back to verify/verifyAndFix
     for (const id of [sibling, ...sibling.findAll({ rule: { kind: 'identifier' } })]) {
-      if (id.kind() !== 'identifier') continue
+      if (!id.is('identifier')) continue
       // Guard: definition() requires a semantic provider — not always available
       if (typeof id.definition !== 'function') break
 
@@ -90,33 +88,27 @@ function isInLintMessageContext(pair: SgNode<JS>): boolean {
       if (def?.kind !== 'local') continue
 
       const declarator = def.node.parent()
-      if (declarator?.kind() !== 'variable_declarator') continue
+      if (!declarator?.is('variable_declarator')) continue
 
-      if (
-        declarator.find({
-          rule: {
-            kind: 'call_expression',
-            has: {
-              field: 'function',
-              has: { kind: 'property_identifier', regex: '^verify(AndFix)?$' },
-            },
+      const verifyCall = declarator.find({
+        rule: {
+          kind: 'call_expression',
+          has: {
+            field: 'function',
+            has: { kind: 'property_identifier', regex: '^verify(AndFix)?$' },
           },
-        })
-      )
-        return true
+        },
+      })
+      if (verifyCall !== null) return true
     }
 
     // Check 3: fallback — sibling is or contains a subscript_expression (messages[N])
     // Combined with the file-level eslint import guard this is a strong enough signal
-    if (sibling.kind() === 'subscript_expression' || sibling.find({ rule: { kind: 'subscript_expression' } }))
-      return true
+    if (sibling.is('subscript_expression') || sibling.find({ rule: { kind: 'subscript_expression' } })) return true
   }
 
   return false
 }
-
-// .nodeType member access on any object — flag with TODO for manual removal
-const NODETYPE_MEMBER_RE = /\.nodeType\b/g
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
   const rootNode = root.root()
@@ -124,11 +116,29 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
 
   // Guard: only process files that import from eslint to avoid touching unrelated
   // objects that happen to have a nodeType property
-  const hasEslintImport =
-    /from\s+['"]eslint['"]/m.test(source) ||
-    /require\s*\(\s*['"]eslint['"]\s*\)/m.test(source) ||
-    /import\s*\(\s*['"]eslint['"]\s*\)/m.test(source)
-  if (!hasEslintImport) return null
+  const eslintImports = rootNode.findAll({
+    rule: {
+      any: [
+        // ESM: import { Linter } from 'eslint'
+        { kind: 'import_statement', has: { regex: '^[\'"]eslint[\'"]$' } },
+        // CJS: require('eslint')
+        {
+          all: [
+            { kind: 'call_expression', has: { field: 'function', regex: '^require$' } },
+            { has: { regex: '^[\'"]eslint[\'"]$' } },
+          ],
+        },
+        // Dynamic: import('eslint') — parsed as call_expression with import keyword as function
+        {
+          all: [
+            { kind: 'call_expression', has: { field: 'function', kind: 'import' } },
+            { has: { regex: '^[\'"]eslint[\'"]$' } },
+          ],
+        },
+      ],
+    },
+  })
+  if (!eslintImports.length) return null
 
   const allPairs = rootNode.findAll({
     rule: {
@@ -140,15 +150,18 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     },
   })
 
-  // Keep only pairs whose parent object can be identified as a LintMessage
-  const pairs = allPairs.filter(isInLintMessageContext)
+  // 1. Remove nodeType: <value> object property pairs from identified LintMessage objects
+  const edits: Edit[] = []
+  for (const pair of allPairs) {
+    if (!isInLintMessageContext(pair)) continue
+    edits.push(removePairEdit(pair, source))
+  }
 
-  // 1. Remove nodeType: <value> object property pairs
-  let result = pairs.length > 0 ? rootNode.commitEdits(pairs.map((pair) => removePairEdit(pair, source))) : source
+  let result = edits.length > 0 ? rootNode.commitEdits(edits) : source
 
   // 2. Flag remaining .nodeType member accesses with a TODO
   result = result.replaceAll(
-    NODETYPE_MEMBER_RE,
+    /\.nodeType\b/g,
     '.nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */',
   )
 

--- a/codemods/v10/linter-api/scripts/fix-lint-message.ts
+++ b/codemods/v10/linter-api/scripts/fix-lint-message.ts
@@ -1,0 +1,69 @@
+import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// LintMessage.nodeType was removed in ESLint v10.
+// 1. Remove `nodeType: <value>` property pairs from object literals.
+// 2. Flag `.nodeType` member expression accesses with a TODO comment.
+function getSelector(): RuleConfig<JS> {
+  return {
+    rule: {
+      kind: 'pair',
+      has: {
+        kind: 'property_identifier',
+        regex: '^nodeType$',
+      },
+    },
+  }
+}
+
+function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
+  const r = pair.range()
+  const start = r.start.index
+  const end = r.end.index
+
+  // Prefer removing the preceding comma so the trailing element keeps its comma
+  const before = source.slice(0, start)
+  const precedingComma = before.match(/,\s*$/)
+  if (precedingComma) {
+    return { start: start - precedingComma[0].length, end }
+  }
+
+  // First property — remove trailing comma and the leading newline+indent to avoid a blank line
+  const after = source.slice(end)
+  const trailingComma = after.match(/^\s*,/)
+  if (trailingComma) {
+    const leadingNewlineAndIndent = before.match(/\n[ \t]*$/)
+    const adjustedStart = leadingNewlineAndIndent ? start - leadingNewlineAndIndent[0].length : start
+    return { start: adjustedStart, end: end + trailingComma[0].length }
+  }
+
+  return { start, end }
+}
+
+// .nodeType member access on any object — flag with TODO for manual removal
+const NODETYPE_MEMBER_RE = /\.nodeType\b/g
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const rootNode = root.root()
+  const pairs = rootNode.findAll(getSelector())
+
+  const source = rootNode.text()
+  let result = source
+
+  // 1. Remove nodeType: <value> object property pairs
+  if (pairs.length > 0) {
+    const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
+
+    for (const { start, end } of deletions) {
+      result = result.slice(0, start) + result.slice(end)
+    }
+  }
+
+  // 2. Flag remaining .nodeType member accesses with a TODO
+  result = result.replaceAll(
+    NODETYPE_MEMBER_RE,
+    '.nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */',
+  )
+
+  return result === source ? null : result
+}

--- a/codemods/v10/linter-api/scripts/fix-lint-message.ts
+++ b/codemods/v10/linter-api/scripts/fix-lint-message.ts
@@ -1,43 +1,55 @@
-import { type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
+import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 // LintMessage.nodeType was removed in ESLint v10.
 // 1. Remove `nodeType: <value>` property pairs from object literals.
 // 2. Flag `.nodeType` member expression accesses with a TODO comment.
-function getSelector(): RuleConfig<JS> {
-  return {
-    rule: {
-      kind: 'pair',
-      has: {
-        kind: 'property_identifier',
-        regex: '^nodeType$',
-      },
+const selector = {
+  rule: {
+    kind: 'pair',
+    has: {
+      kind: 'property_identifier',
+      regex: '^nodeType$',
     },
-  }
-}
+  },
+} as const satisfies RuleConfig<JS>
 
-function removePairRange(pair: SgNode<JS>, source: string): { start: number; end: number } {
-  const r = pair.range()
-  const start = r.start.index
-  const end = r.end.index
+function removePairEdit(pair: SgNode<JS>, source: string): Edit {
+  const range = pair.range()
+  const start = range.start.index
+  const end = range.end.index
 
   // Prefer removing the preceding comma so the trailing element keeps its comma
   const before = source.slice(0, start)
   const precedingComma = before.match(/,\s*$/)
+
   if (precedingComma) {
-    return { start: start - precedingComma[0].length, end }
+    return {
+      startPos: start - precedingComma[0].length,
+      endPos: end,
+      insertedText: '',
+    }
   }
 
   // First property — remove trailing comma and the leading newline+indent to avoid a blank line
   const after = source.slice(end)
   const trailingComma = after.match(/^\s*,/)
+
   if (trailingComma) {
     const leadingNewlineAndIndent = before.match(/\n[ \t]*$/)
     const adjustedStart = leadingNewlineAndIndent ? start - leadingNewlineAndIndent[0].length : start
-    return { start: adjustedStart, end: end + trailingComma[0].length }
+    return {
+      startPos: adjustedStart,
+      endPos: end + trailingComma[0].length,
+      insertedText: '',
+    }
   }
 
-  return { start, end }
+  return {
+    startPos: start,
+    endPos: end,
+    insertedText: '',
+  }
 }
 
 // .nodeType member access on any object — flag with TODO for manual removal
@@ -45,19 +57,12 @@ const NODETYPE_MEMBER_RE = /\.nodeType\b/g
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
   const rootNode = root.root()
-  const pairs = rootNode.findAll(getSelector())
+  const pairs = rootNode.findAll(selector)
 
   const source = rootNode.text()
-  let result = source
 
   // 1. Remove nodeType: <value> object property pairs
-  if (pairs.length > 0) {
-    const deletions = pairs.map((pair) => removePairRange(pair, source)).sort((a, b) => b.start - a.start)
-
-    for (const { start, end } of deletions) {
-      result = result.slice(0, start) + result.slice(end)
-    }
-  }
+  let result = pairs.length > 0 ? rootNode.commitEdits(pairs.map((pair) => removePairEdit(pair, source))) : source
 
   // 2. Flag remaining .nodeType member accesses with a TODO
   result = result.replaceAll(

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -16,8 +16,9 @@ const LINTER_ESLINTRC_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])esl
 // loadESLint({ useFlatConfig: true/false }) → loadESLint()
 const LOAD_ESLINT_RE = /loadESLint\s*\(\s*\{\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
 
-// ─── ESLint flags array: remove removed flag values ──────────────────────────
+// ─── ESLint flags array: remove removed flag values from flags: [...] only ───
 const REMOVED_FLAGS = ['v10_config_lookup_from_file', 'unstable_config_lookup_from_file']
+const FLAGS_ARRAY_RE = /\bflags\s*:\s*\[([^\]]*)\]/g
 
 // ─── Deprecated Linter instance methods removed in v10 ──────────────────────
 const DEPRECATED_METHODS = ['defineParser', 'defineRule', 'defineRules', 'getRules']
@@ -54,15 +55,19 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   // 4. loadESLint({ useFlatConfig: ... }) → loadESLint()
   result = result.replaceAll(LOAD_ESLINT_RE, 'loadESLint()')
 
-  // 5. Remove removed flag values from new ESLint({ flags: [...] })
-  for (const flag of REMOVED_FLAGS) {
-    result = result.replaceAll(new RegExp(`(['"\`])${flag}\\1\\s*,?|,?\\s*(['"\`])${flag}\\2`, 'g'), '')
-    result = result
-      .replaceAll(/\[\s*,\s*/g, '[')
-      .replaceAll(/,\s*\]/g, ']')
+  // 5. Remove removed flag values — scoped to flags: [...] only to avoid touching unrelated strings
+  result = result.replaceAll(FLAGS_ARRAY_RE, (_m: string, inner: string) => {
+    let arr = inner
+    for (const flag of REMOVED_FLAGS) {
+      arr = arr.replaceAll(new RegExp(`(['"\`])${flag}\\1\\s*,?|,?\\s*(['"\`])${flag}\\2`, 'g'), '')
+    }
+    arr = arr
+      .replace(/^\s*,\s*/, '')
+      .replace(/,\s*$/, '')
       .replaceAll(/,\s*,/g, ',')
-      .replaceAll(/\[\s+(['"`])/g, '[$1')
-  }
+      .trim()
+    return `flags: [${arr}]`
+  })
 
   // 6. Deprecated Linter instance methods → TODO comment
   for (const method of DEPRECATED_METHODS) {

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -1,9 +1,27 @@
-import type { Edit, SgNode, SgRoot } from 'codemod:ast-grep'
+import type { Edit, RuleConfig, SgNode, SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 const ESLINTRC_TODO = '/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */'
 const REMOVED_FLAGS = new Set(['v10_config_lookup_from_file', 'unstable_config_lookup_from_file'])
 const DEPRECATED_METHODS = ['defineParser', 'defineRule', 'defineRules', 'getRules']
+
+const linterNewExprSelector = {
+  rule: {
+    kind: 'new_expression',
+    has: { field: 'constructor', regex: '^Linter$' },
+  },
+} as RuleConfig<JS>
+
+const loadESLintCallSelector = {
+  rule: {
+    kind: 'call_expression',
+    has: { field: 'function', regex: '^loadESLint$' },
+  },
+} as RuleConfig<JS>
+
+const flagsPairSelector = {
+  rule: { kind: 'pair', has: { field: 'key', regex: '^flags$' } },
+} as RuleConfig<JS>
 
 function namedChildren(node: SgNode<JS>): SgNode<JS>[] {
   return node.children().filter((c) => c.isNamed())
@@ -19,12 +37,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   const edits: Edit[] = []
 
   // ── 1–4. new Linter({ configType: 'flat'|'eslintrc' }) ───────────────────────
-  for (const newExpr of rootNode.findAll({
-    rule: {
-      kind: 'new_expression',
-      has: { field: 'constructor', regex: '^Linter$' },
-    },
-  })) {
+  for (const newExpr of rootNode.findAll(linterNewExprSelector)) {
     const argsNode = newExpr.find({ rule: { kind: 'arguments' } })
     if (!argsNode) continue
     const argObj = argsNode.find({ rule: { kind: 'object' } })
@@ -58,12 +71,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   }
 
   // ── 5–6. loadESLint({ useFlatConfig: true|false }) ───────────────────────────
-  for (const callExpr of rootNode.findAll({
-    rule: {
-      kind: 'call_expression',
-      has: { field: 'function', regex: '^loadESLint$' },
-    },
-  })) {
+  for (const callExpr of rootNode.findAll(loadESLintCallSelector)) {
     const argsNode = callExpr.find({ rule: { kind: 'arguments' } })
     if (!argsNode) continue
     const argObj = argsNode.find({ rule: { kind: 'object' } })
@@ -86,9 +94,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   }
 
   // ── 7. flags: [...] — remove removed flag values ─────────────────────────────
-  for (const pair of rootNode.findAll({
-    rule: { kind: 'pair', has: { field: 'key', regex: '^flags$' } },
-  })) {
+  for (const pair of rootNode.findAll(flagsPairSelector)) {
     const arrayNode = pair.find({ rule: { kind: 'array' } })
     if (!arrayNode) continue
 
@@ -125,5 +131,6 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   }
 
   if (!edits.length) return null
+
   return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -1,0 +1,76 @@
+import { type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// ─── Linter constructor: configType option removed ───────────────────────────
+// new Linter({ configType: 'flat' }) → new Linter()
+const LINTER_FLAT_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])flat\1\s*\}\s*\)/g
+
+// new Linter({ configType: 'flat', ...rest }) → new Linter({ ...rest })
+const LINTER_FLAT_LEADING_RE = /new\s+Linter\s*\(\s*\{([^}]*?)configType\s*:\s*(['"`])flat\2\s*,([^}]*?)\}\s*\)/g
+const LINTER_FLAT_TRAILING_RE = /new\s+Linter\s*\(\s*\{([^}]*?),\s*configType\s*:\s*(['"`])flat\2\s*\}\s*\)/g
+
+// new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
+const LINTER_ESLINTRC_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])eslintrc\1\s*\}\s*\)/g
+
+// ─── loadESLint: useFlatConfig option removed ────────────────────────────────
+// loadESLint({ useFlatConfig: true/false }) → loadESLint()
+const LOAD_ESLINT_RE = /loadESLint\s*\(\s*\{\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
+
+// ─── ESLint flags array: remove removed flag values ──────────────────────────
+const REMOVED_FLAGS = ['v10_config_lookup_from_file', 'unstable_config_lookup_from_file']
+
+// ─── Deprecated Linter instance methods removed in v10 ──────────────────────
+const DEPRECATED_METHODS = ['defineParser', 'defineRule', 'defineRules', 'getRules']
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const source = root.root().text()
+  let result = source
+
+  // 1. new Linter({ configType: 'flat' }) → new Linter()
+  result = result.replaceAll(LINTER_FLAT_RE, 'new Linter()')
+
+  // 2. new Linter({ configType: 'flat', ...rest }) → new Linter({ ...rest })
+  // Leading: configType is first/middle — keep options before AND after it
+  result = result.replaceAll(LINTER_FLAT_LEADING_RE, (_m: string, before: string, _q: string, after: string) => {
+    const b = before.trim().replace(/,\s*$/, '')
+    const a = after.trim().replace(/^,\s*/, '')
+    const parts = [b, a].filter(Boolean).join(', ')
+    return parts ? `new Linter({ ${parts} })` : 'new Linter()'
+  })
+  // Trailing: configType is last — keep everything before it
+  result = result.replaceAll(LINTER_FLAT_TRAILING_RE, (_m: string, before: string) => {
+    const rest = before.trim().replace(/,\s*$/, '')
+    return rest ? `new Linter({ ${rest} })` : 'new Linter()'
+  })
+  // Clean up empty object literals left behind by multiline cases
+  result = result.replaceAll(/new\s+Linter\s*\(\s*\{\s*\}\s*\)/g, 'new Linter()')
+
+  // 3. new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
+  result = result.replaceAll(
+    LINTER_ESLINTRC_RE,
+    'new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)',
+  )
+
+  // 4. loadESLint({ useFlatConfig: ... }) → loadESLint()
+  result = result.replaceAll(LOAD_ESLINT_RE, 'loadESLint()')
+
+  // 5. Remove removed flag values from new ESLint({ flags: [...] })
+  for (const flag of REMOVED_FLAGS) {
+    result = result.replaceAll(new RegExp(`(['"\`])${flag}\\1\\s*,?|,?\\s*(['"\`])${flag}\\2`, 'g'), '')
+    result = result
+      .replaceAll(/\[\s*,\s*/g, '[')
+      .replaceAll(/,\s*\]/g, ']')
+      .replaceAll(/,\s*,/g, ',')
+      .replaceAll(/\[\s+(['"`])/g, '[$1')
+  }
+
+  // 6. Deprecated Linter instance methods → TODO comment
+  for (const method of DEPRECATED_METHODS) {
+    result = result.replaceAll(
+      new RegExp(`\\.${method}\\s*\\(`, 'g'),
+      `.${method}(/* TODO: ${method}() removed in ESLint v10, no replacement */ `,
+    )
+  }
+
+  return result === source ? null : result
+}

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -12,9 +12,20 @@ const LINTER_FLAT_TRAILING_RE = /new\s+Linter\s*\(\s*\{([^}]*?),\s*configType\s*
 // new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
 const LINTER_ESLINTRC_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])eslintrc\1\s*\}\s*\)/g
 
+// new Linter({ configType: 'eslintrc', ...rest }) → new Linter({ ...rest /* TODO */ })
+const LINTER_ESLINTRC_LEADING_RE =
+  /new\s+Linter\s*\(\s*\{([^}]*?)configType\s*:\s*(['"`])eslintrc\2\s*,([^}]*?)\}\s*\)/g
+const LINTER_ESLINTRC_TRAILING_RE = /new\s+Linter\s*\(\s*\{([^}]*?),\s*configType\s*:\s*(['"`])eslintrc\2\s*\}\s*\)/g
+
+const ESLINTRC_TODO = '/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */'
+
 // ─── loadESLint: useFlatConfig option removed ────────────────────────────────
 // loadESLint({ useFlatConfig: true/false }) → loadESLint()
 const LOAD_ESLINT_RE = /loadESLint\s*\(\s*\{\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
+
+// loadESLint({ useFlatConfig: true/false, ...rest }) → loadESLint({ ...rest })
+const LOAD_ESLINT_LEADING_RE = /loadESLint\s*\(\s*\{([^}]*?)useFlatConfig\s*:\s*(?:true|false)\s*,([^}]*?)\}\s*\)/g
+const LOAD_ESLINT_TRAILING_RE = /loadESLint\s*\(\s*\{([^}]*?),\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
 
 // ─── ESLint flags array: remove removed flag values from flags: [...] only ───
 const REMOVED_FLAGS = ['v10_config_lookup_from_file', 'unstable_config_lookup_from_file']
@@ -47,15 +58,36 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   result = result.replaceAll(/new\s+Linter\s*\(\s*\{\s*\}\s*\)/g, 'new Linter()')
 
   // 3. new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
-  result = result.replaceAll(
-    LINTER_ESLINTRC_RE,
-    'new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)',
-  )
+  result = result.replaceAll(LINTER_ESLINTRC_RE, `new Linter(${ESLINTRC_TODO})`)
 
-  // 4. loadESLint({ useFlatConfig: ... }) → loadESLint()
+  // 4. new Linter({ configType: 'eslintrc', ...rest }) → new Linter({ ...rest /* TODO */ })
+  result = result.replaceAll(LINTER_ESLINTRC_LEADING_RE, (_m: string, before: string, _q: string, after: string) => {
+    const b = before.trim().replace(/,\s*$/, '')
+    const a = after.trim().replace(/^,\s*/, '')
+    const parts = [b, a].filter(Boolean).join(', ')
+    return parts ? `new Linter({ ${parts} ${ESLINTRC_TODO} })` : `new Linter(${ESLINTRC_TODO})`
+  })
+  result = result.replaceAll(LINTER_ESLINTRC_TRAILING_RE, (_m: string, before: string) => {
+    const rest = before.trim().replace(/,\s*$/, '')
+    return rest ? `new Linter({ ${rest} ${ESLINTRC_TODO} })` : `new Linter(${ESLINTRC_TODO})`
+  })
+
+  // 5. loadESLint({ useFlatConfig: ... }) → loadESLint()
   result = result.replaceAll(LOAD_ESLINT_RE, 'loadESLint()')
 
-  // 5. Remove removed flag values — scoped to flags: [...] only to avoid touching unrelated strings
+  // 6. loadESLint({ useFlatConfig: ..., ...rest }) → loadESLint({ ...rest })
+  result = result.replaceAll(LOAD_ESLINT_LEADING_RE, (_m: string, before: string, after: string) => {
+    const b = before.trim().replace(/,\s*$/, '')
+    const a = after.trim().replace(/^,\s*/, '')
+    const parts = [b, a].filter(Boolean).join(', ')
+    return parts ? `loadESLint({ ${parts} })` : 'loadESLint()'
+  })
+  result = result.replaceAll(LOAD_ESLINT_TRAILING_RE, (_m: string, before: string) => {
+    const rest = before.trim().replace(/,\s*$/, '')
+    return rest ? `loadESLint({ ${rest} })` : 'loadESLint()'
+  })
+
+  // 7. Remove removed flag values — scoped to flags: [...] only to avoid touching unrelated strings
   result = result.replaceAll(FLAGS_ARRAY_RE, (_m: string, inner: string) => {
     let arr = inner
     for (const flag of REMOVED_FLAGS) {
@@ -69,7 +101,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     return `flags: [${arr}]`
   })
 
-  // 6. Deprecated Linter instance methods → TODO comment
+  // 8. Deprecated Linter instance methods → TODO comment
   for (const method of DEPRECATED_METHODS) {
     result = result.replaceAll(
       new RegExp(`\\.${method}\\s*\\(`, 'g'),

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -1,4 +1,4 @@
-import { type SgRoot } from 'codemod:ast-grep'
+import type { SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 // ─── Linter constructor: configType option removed ───────────────────────────

--- a/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
+++ b/codemods/v10/linter-api/scripts/fix-linter-constructor.ts
@@ -1,113 +1,129 @@
-import type { SgRoot } from 'codemod:ast-grep'
+import type { Edit, SgNode, SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
-// ─── Linter constructor: configType option removed ───────────────────────────
-// new Linter({ configType: 'flat' }) → new Linter()
-const LINTER_FLAT_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])flat\1\s*\}\s*\)/g
-
-// new Linter({ configType: 'flat', ...rest }) → new Linter({ ...rest })
-const LINTER_FLAT_LEADING_RE = /new\s+Linter\s*\(\s*\{([^}]*?)configType\s*:\s*(['"`])flat\2\s*,([^}]*?)\}\s*\)/g
-const LINTER_FLAT_TRAILING_RE = /new\s+Linter\s*\(\s*\{([^}]*?),\s*configType\s*:\s*(['"`])flat\2\s*\}\s*\)/g
-
-// new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
-const LINTER_ESLINTRC_RE = /new\s+Linter\s*\(\s*\{\s*configType\s*:\s*(['"`])eslintrc\1\s*\}\s*\)/g
-
-// new Linter({ configType: 'eslintrc', ...rest }) → new Linter({ ...rest /* TODO */ })
-const LINTER_ESLINTRC_LEADING_RE =
-  /new\s+Linter\s*\(\s*\{([^}]*?)configType\s*:\s*(['"`])eslintrc\2\s*,([^}]*?)\}\s*\)/g
-const LINTER_ESLINTRC_TRAILING_RE = /new\s+Linter\s*\(\s*\{([^}]*?),\s*configType\s*:\s*(['"`])eslintrc\2\s*\}\s*\)/g
-
 const ESLINTRC_TODO = '/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */'
-
-// ─── loadESLint: useFlatConfig option removed ────────────────────────────────
-// loadESLint({ useFlatConfig: true/false }) → loadESLint()
-const LOAD_ESLINT_RE = /loadESLint\s*\(\s*\{\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
-
-// loadESLint({ useFlatConfig: true/false, ...rest }) → loadESLint({ ...rest })
-const LOAD_ESLINT_LEADING_RE = /loadESLint\s*\(\s*\{([^}]*?)useFlatConfig\s*:\s*(?:true|false)\s*,([^}]*?)\}\s*\)/g
-const LOAD_ESLINT_TRAILING_RE = /loadESLint\s*\(\s*\{([^}]*?),\s*useFlatConfig\s*:\s*(?:true|false)\s*\}\s*\)/g
-
-// ─── ESLint flags array: remove removed flag values from flags: [...] only ───
-const REMOVED_FLAGS = ['v10_config_lookup_from_file', 'unstable_config_lookup_from_file']
-const FLAGS_ARRAY_RE = /\bflags\s*:\s*\[([^\]]*)\]/g
-
-// ─── Deprecated Linter instance methods removed in v10 ──────────────────────
+const REMOVED_FLAGS = new Set(['v10_config_lookup_from_file', 'unstable_config_lookup_from_file'])
 const DEPRECATED_METHODS = ['defineParser', 'defineRule', 'defineRules', 'getRules']
 
+function namedChildren(node: SgNode<JS>): SgNode<JS>[] {
+  return node.children().filter((c) => c.isNamed())
+}
+
+// Reconstruct an object literal from a subset of its named children's source text.
+function rebuildObject(children: SgNode<JS>[]): string {
+  return `{ ${children.map((n) => n.text()).join(', ')} }`
+}
+
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
-  const source = root.root().text()
-  let result = source
+  const rootNode = root.root()
+  const edits: Edit[] = []
 
-  // 1. new Linter({ configType: 'flat' }) → new Linter()
-  result = result.replaceAll(LINTER_FLAT_RE, 'new Linter()')
+  // ── 1–4. new Linter({ configType: 'flat'|'eslintrc' }) ───────────────────────
+  for (const newExpr of rootNode.findAll({
+    rule: {
+      kind: 'new_expression',
+      has: { field: 'constructor', regex: '^Linter$' },
+    },
+  })) {
+    const argsNode = newExpr.find({ rule: { kind: 'arguments' } })
+    if (!argsNode) continue
+    const argObj = argsNode.find({ rule: { kind: 'object' } })
+    if (!argObj) continue
 
-  // 2. new Linter({ configType: 'flat', ...rest }) → new Linter({ ...rest })
-  // Leading: configType is first/middle — keep options before AND after it
-  result = result.replaceAll(LINTER_FLAT_LEADING_RE, (_m: string, before: string, _q: string, after: string) => {
-    const b = before.trim().replace(/,\s*$/, '')
-    const a = after.trim().replace(/^,\s*/, '')
-    const parts = [b, a].filter(Boolean).join(', ')
-    return parts ? `new Linter({ ${parts} })` : 'new Linter()'
-  })
-  // Trailing: configType is last — keep everything before it
-  result = result.replaceAll(LINTER_FLAT_TRAILING_RE, (_m: string, before: string) => {
-    const rest = before.trim().replace(/,\s*$/, '')
-    return rest ? `new Linter({ ${rest} })` : 'new Linter()'
-  })
-  // Clean up empty object literals left behind by multiline cases
-  result = result.replaceAll(/new\s+Linter\s*\(\s*\{\s*\}\s*\)/g, 'new Linter()')
+    const configTypePair = argObj.find({
+      rule: { kind: 'pair', has: { field: 'key', regex: '^configType$' } },
+    })
+    if (!configTypePair) continue
 
-  // 3. new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
-  result = result.replaceAll(LINTER_ESLINTRC_RE, `new Linter(${ESLINTRC_TODO})`)
+    const configTypeVal = configTypePair.find({ rule: { kind: 'string_fragment' } })?.text() ?? ''
+    if (configTypeVal !== 'flat' && configTypeVal !== 'eslintrc') continue
 
-  // 4. new Linter({ configType: 'eslintrc', ...rest }) → new Linter({ ...rest /* TODO */ })
-  result = result.replaceAll(LINTER_ESLINTRC_LEADING_RE, (_m: string, before: string, _q: string, after: string) => {
-    const b = before.trim().replace(/,\s*$/, '')
-    const a = after.trim().replace(/^,\s*/, '')
-    const parts = [b, a].filter(Boolean).join(', ')
-    return parts ? `new Linter({ ${parts} ${ESLINTRC_TODO} })` : `new Linter(${ESLINTRC_TODO})`
-  })
-  result = result.replaceAll(LINTER_ESLINTRC_TRAILING_RE, (_m: string, before: string) => {
-    const rest = before.trim().replace(/,\s*$/, '')
-    return rest ? `new Linter({ ${rest} ${ESLINTRC_TODO} })` : `new Linter(${ESLINTRC_TODO})`
-  })
+    const otherChildren = namedChildren(argObj).filter((n) => n.id() !== configTypePair.id())
 
-  // 5. loadESLint({ useFlatConfig: ... }) → loadESLint()
-  result = result.replaceAll(LOAD_ESLINT_RE, 'loadESLint()')
-
-  // 6. loadESLint({ useFlatConfig: ..., ...rest }) → loadESLint({ ...rest })
-  result = result.replaceAll(LOAD_ESLINT_LEADING_RE, (_m: string, before: string, after: string) => {
-    const b = before.trim().replace(/,\s*$/, '')
-    const a = after.trim().replace(/^,\s*/, '')
-    const parts = [b, a].filter(Boolean).join(', ')
-    return parts ? `loadESLint({ ${parts} })` : 'loadESLint()'
-  })
-  result = result.replaceAll(LOAD_ESLINT_TRAILING_RE, (_m: string, before: string) => {
-    const rest = before.trim().replace(/,\s*$/, '')
-    return rest ? `loadESLint({ ${rest} })` : 'loadESLint()'
-  })
-
-  // 7. Remove removed flag values — scoped to flags: [...] only to avoid touching unrelated strings
-  result = result.replaceAll(FLAGS_ARRAY_RE, (_m: string, inner: string) => {
-    let arr = inner
-    for (const flag of REMOVED_FLAGS) {
-      arr = arr.replaceAll(new RegExp(`(['"\`])${flag}\\1\\s*,?|,?\\s*(['"\`])${flag}\\2`, 'g'), '')
+    if (configTypeVal === 'flat') {
+      if (!otherChildren.length) {
+        // new Linter({ configType: 'flat' }) → new Linter()
+        edits.push(argsNode.replace('()'))
+      } else {
+        // new Linter({ configType: 'flat', ...rest }) → new Linter({ ...rest })
+        edits.push(argObj.replace(rebuildObject(otherChildren)))
+      }
+    } else if (!otherChildren.length) {
+      // new Linter({ configType: 'eslintrc' }) → new Linter(/* TODO */)
+      edits.push(argsNode.replace(`(${ESLINTRC_TODO})`))
+    } else {
+      // new Linter({ configType: 'eslintrc', ...rest }) → new Linter({ ...rest /* TODO */ })
+      edits.push(argObj.replace(`{ ${otherChildren.map((n) => n.text()).join(', ')} ${ESLINTRC_TODO} }`))
     }
-    arr = arr
-      .replace(/^\s*,\s*/, '')
-      .replace(/,\s*$/, '')
-      .replaceAll(/,\s*,/g, ',')
-      .trim()
-    return `flags: [${arr}]`
-  })
-
-  // 8. Deprecated Linter instance methods → TODO comment
-  for (const method of DEPRECATED_METHODS) {
-    result = result.replaceAll(
-      new RegExp(`\\.${method}\\s*\\(`, 'g'),
-      `.${method}(/* TODO: ${method}() removed in ESLint v10, no replacement */ `,
-    )
   }
 
-  return result === source ? null : result
+  // ── 5–6. loadESLint({ useFlatConfig: true|false }) ───────────────────────────
+  for (const callExpr of rootNode.findAll({
+    rule: {
+      kind: 'call_expression',
+      has: { field: 'function', regex: '^loadESLint$' },
+    },
+  })) {
+    const argsNode = callExpr.find({ rule: { kind: 'arguments' } })
+    if (!argsNode) continue
+    const argObj = argsNode.find({ rule: { kind: 'object' } })
+    if (!argObj) continue
+
+    const useFlatConfigPair = argObj.find({
+      rule: { kind: 'pair', has: { field: 'key', regex: '^useFlatConfig$' } },
+    })
+    if (!useFlatConfigPair) continue
+
+    const otherChildren = namedChildren(argObj).filter((n) => n.id() !== useFlatConfigPair.id())
+
+    if (!otherChildren.length) {
+      // loadESLint({ useFlatConfig: ... }) → loadESLint()
+      edits.push(argsNode.replace('()'))
+    } else {
+      // loadESLint({ useFlatConfig: ..., ...rest }) → loadESLint({ ...rest })
+      edits.push(argObj.replace(rebuildObject(otherChildren)))
+    }
+  }
+
+  // ── 7. flags: [...] — remove removed flag values ─────────────────────────────
+  for (const pair of rootNode.findAll({
+    rule: { kind: 'pair', has: { field: 'key', regex: '^flags$' } },
+  })) {
+    const arrayNode = pair.find({ rule: { kind: 'array' } })
+    if (!arrayNode) continue
+
+    const allElems = namedChildren(arrayNode).filter((e) => e.kind() === 'string')
+    const keptElems = allElems.filter(
+      (e) => !REMOVED_FLAGS.has(e.find({ rule: { kind: 'string_fragment' } })?.text() ?? ''),
+    )
+
+    if (keptElems.length < allElems.length) {
+      edits.push(arrayNode.replace(`[${keptElems.map((e) => e.text()).join(', ')}]`))
+    }
+  }
+
+  // ── 8. Deprecated Linter instance methods → TODO comment ─────────────────────
+  for (const method of DEPRECATED_METHODS) {
+    for (const callExpr of rootNode.findAll({
+      rule: {
+        kind: 'call_expression',
+        has: {
+          field: 'function',
+          has: { kind: 'property_identifier', regex: `^${method}$` },
+        },
+      },
+    })) {
+      const argsNode = callExpr.find({ rule: { kind: 'arguments' } })
+      if (!argsNode) continue
+      const insertPos = argsNode.range().start.index + 1 // after '('
+      edits.push({
+        startPos: insertPos,
+        endPos: insertPos,
+        insertedText: `/* TODO: ${method}() removed in ESLint v10, no replacement */ `,
+      })
+    }
+  }
+
+  if (!edits.length) return null
+  return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -6,15 +6,15 @@ const RADIX_AS_NEEDED_TODO =
 
 const funcNamesPairSelector = {
   rule: { kind: 'pair', has: { field: 'key', regex: 'func-names' } },
-} as const satisfies RuleConfig<JS>
+} as RuleConfig<JS>
 
 const allowConstructorFlagsPairSelector = {
   rule: { kind: 'pair', has: { field: 'key', regex: 'allowConstructorFlags' } },
-} as const satisfies RuleConfig<JS>
+} as RuleConfig<JS>
 
 const radixPairSelector = {
   rule: { kind: 'pair', has: { field: 'key', regex: 'radix' } },
-} as const satisfies RuleConfig<JS>
+} as RuleConfig<JS>
 
 // Named (non-punctuation) children of a node
 function namedChildren(node: SgNode<JS>): SgNode<JS>[] {

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -6,8 +6,9 @@ import type JS from 'codemod:ast-grep/langs/javascript'
 // Before: ["error", "always", {}, "as-needed"]
 // After:  ["error", "always", {}]
 // Pattern: severity , mode_string , options_object , extra_mode_string ]
+// Options object pattern handles one level of nesting: { generators: { mode: 'strict' } }
 const FUNC_NAMES_RE =
-  /(['"`]func-names['"`]\s*:\s*\[)(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{[^}]*\})\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*(\])/g
+  /(['"`]func-names['"`]\s*:\s*\[)(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)?\})\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*(\])/g
 
 // no-invalid-regexp: ESLint v10 rejects duplicate flags in allowConstructorFlags.
 // Before: { allowConstructorFlags: ["u", "y", "u"] }

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -1,8 +1,20 @@
-import type { Edit, SgNode, SgRoot } from 'codemod:ast-grep'
+import type { Edit, RuleConfig, SgNode, SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
 const RADIX_AS_NEEDED_TODO =
   '/* TODO: "as-needed" is removed in ESLint v10 — remove the "as-needed" option or disable the rule */'
+
+const funcNamesPairSelector = {
+  rule: { kind: 'pair', has: { field: 'key', regex: 'func-names' } },
+} as const satisfies RuleConfig<JS>
+
+const allowConstructorFlagsPairSelector = {
+  rule: { kind: 'pair', has: { field: 'key', regex: 'allowConstructorFlags' } },
+} as const satisfies RuleConfig<JS>
+
+const radixPairSelector = {
+  rule: { kind: 'pair', has: { field: 'key', regex: 'radix' } },
+} as const satisfies RuleConfig<JS>
 
 // Named (non-punctuation) children of a node
 function namedChildren(node: SgNode<JS>): SgNode<JS>[] {
@@ -15,9 +27,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
 
   // ── 1. func-names: Remove extra 4th string element ──────────────────────────
   // ESLint v10 no longer accepts [severity, mode, options, extraMode]; strip extraMode.
-  for (const pair of rootNode.findAll({
-    rule: { kind: 'pair', has: { field: 'key', regex: 'func-names' } },
-  })) {
+  for (const pair of rootNode.findAll(funcNamesPairSelector)) {
     const arrayNode = pair.find({ rule: { kind: 'array' } })
     if (!arrayNode) continue
 
@@ -32,61 +42,45 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     const match = arrayText.match(trailingStringRe)
     if (!match) continue
 
-    const { start, end } = arrayNode.range()
-    edits.push({
-      startPos: start.index,
-      endPos: end.index,
-      insertedText: `${arrayText.slice(0, arrayText.length - match[0].length)}]`,
-    })
+    edits.push(arrayNode.replace(`${arrayText.slice(0, arrayText.length - match[0].length)}]`))
   }
 
   // ── 2. no-invalid-regexp: Deduplicate allowConstructorFlags values ────────────
   // ESLint v10 rejects duplicate flags; keep only the first occurrence of each.
-  for (const pair of rootNode.findAll({
-    rule: { kind: 'pair', has: { field: 'key', regex: 'allowConstructorFlags' } },
-  })) {
+  for (const pair of rootNode.findAll(allowConstructorFlagsPairSelector)) {
     const arrayNode = pair.find({ rule: { kind: 'array' } })
     if (!arrayNode) continue
 
-    const stringElems = namedChildren(arrayNode).filter((e) => e.kind() === 'string')
+    const allFragments = arrayNode.findAll({ rule: { kind: 'string_fragment' } })
     const seen = new Set<string>()
-    const uniqueElems: SgNode<JS>[] = []
-    for (const elem of stringElems) {
-      const flag = elem.text().replaceAll(/['"` ]/g, '')
-      if (!seen.has(flag)) {
-        seen.add(flag)
-        uniqueElems.push(elem)
+    const uniqueFragments: SgNode<JS>[] = []
+    for (const frag of allFragments) {
+      if (!seen.has(frag.text())) {
+        seen.add(frag.text())
+        uniqueFragments.push(frag)
       }
     }
 
-    if (uniqueElems.length < stringElems.length) {
-      const { start, end } = arrayNode.range()
-      edits.push({
-        startPos: start.index,
-        endPos: end.index,
-        insertedText: `[${uniqueElems.map((e) => e.text()).join(', ')}]`,
-      })
+    if (uniqueFragments.length < allFragments.length) {
+      edits.push(arrayNode.replace(`[${uniqueFragments.map((f) => f.parent()?.text() ?? '').join(', ')}]`))
     }
   }
 
   // ── 3. radix: Handle deprecated 'always' and 'as-needed' options ─────────────
-  for (const pair of rootNode.findAll({
-    rule: { kind: 'pair', has: { field: 'key', regex: 'radix' } },
-  })) {
+  for (const pair of rootNode.findAll(radixPairSelector)) {
     const arrayNode = pair.find({ rule: { kind: 'array' } })
     if (!arrayNode) continue
 
     const elems = namedChildren(arrayNode)
     const severity = elems[0]
     const option = elems[1]
-    if (!severity || option?.kind() !== 'string') continue
+    if (!severity || !option?.is('string')) continue
 
-    const optionVal = option.text().replaceAll(/['"` ]/g, '')
+    const optionVal = option.find({ rule: { kind: 'string_fragment' } })?.text() ?? ''
 
     if (optionVal === 'always') {
       // ['error', 'always'] → 'error'  (strip redundant option; 'always' is the only v10 behavior)
-      const { start, end } = arrayNode.range()
-      edits.push({ startPos: start.index, endPos: end.index, insertedText: severity.text() })
+      edits.push(arrayNode.replace(severity.text()))
     } else if (optionVal === 'as-needed') {
       // ['error', 'as-needed'] → ['error', /* TODO */ 'as-needed']
       const insertPos = option.range().start.index
@@ -94,6 +88,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     }
   }
 
-  if (edits.length === 0) return null
+  if (!edits.length) return null
+
   return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -1,0 +1,65 @@
+import { type SgRoot } from 'codemod:ast-grep'
+import type JS from 'codemod:ast-grep/langs/javascript'
+
+// func-names: ESLint v10 no longer accepts a 4th array element (the trailing mode string).
+// The valid schema is [severity, mode?, options?] — a 4th element is rejected.
+// Before: ["error", "always", {}, "as-needed"]
+// After:  ["error", "always", {}]
+// Pattern: severity , mode_string , options_object , extra_mode_string ]
+const FUNC_NAMES_RE =
+  /(['"`]func-names['"`]\s*:\s*\[)(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{[^}]*\})\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*(\])/g
+
+// no-invalid-regexp: ESLint v10 rejects duplicate flags in allowConstructorFlags.
+// Before: { allowConstructorFlags: ["u", "y", "u"] }
+// After:  { allowConstructorFlags: ["u", "y"] }
+const ALLOW_CONSTRUCTOR_FLAGS_RE = /allowConstructorFlags\s*:\s*\[([^\]]+)\]/g
+
+// radix: string options "always" and "as-needed" are deprecated in v10.
+// "always" is the only effective behavior now, so it can be stripped.
+// Before: 'radix': ['error', 'always']
+// After:  'radix': 'error'
+const RADIX_ALWAYS_RE = /(['"`]radix['"`]\s*:\s*)\[(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*),\s*(['"`])always\3\s*\]/g
+
+// "as-needed" changed behavior — flag with TODO.
+// Before: 'radix': ['error', 'as-needed']
+// After:  'radix': ['error', /* TODO */ 'as-needed']
+const RADIX_AS_NEEDED_RE = /(['"`]radix['"`]\s*:\s*\[\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*)(,\s*)(['"`])as-needed\3/g
+
+function deduplicateFlags(match: string, inner: string): string {
+  const flags = inner.match(/['"`][^'"`]*['"`]/g) ?? []
+  const seen = new Set<string>()
+  const unique = flags.filter((f) => {
+    const key = f.replaceAll(/['"` ]/g, '')
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  if (unique.length === flags.length) return match
+  return `allowConstructorFlags: [${unique.join(', ')}]`
+}
+
+export default async function transform(root: SgRoot<JS>): Promise<string | null> {
+  const source = root.root().text()
+  let result = source
+
+  // 1. Remove extra 4th element from func-names array config
+  result = result.replaceAll(FUNC_NAMES_RE, (_match, open, body, close) => `${open}${body}${close}`)
+
+  // 2. Deduplicate allowConstructorFlags in no-invalid-regexp
+  result = result.replaceAll(ALLOW_CONSTRUCTOR_FLAGS_RE, deduplicateFlags)
+
+  // 3. radix "always": strip the redundant option (default behavior in v10)
+  result = result.replaceAll(
+    RADIX_ALWAYS_RE,
+    (_: string, prefix: string, severity: string) => `${prefix}${severity.trim()}`,
+  )
+
+  // 4. radix "as-needed": flag with TODO — the option is deprecated and behavior changed
+  result = result.replaceAll(
+    RADIX_AS_NEEDED_RE,
+    (_: string, open: string, sep: string, q: string) =>
+      `${open}${sep}/* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ ${q}as-needed${q}`,
+  )
+
+  return result === source ? null : result
+}

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -1,66 +1,99 @@
-import { type SgRoot } from 'codemod:ast-grep'
+import type { Edit, SgNode, SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
-// func-names: ESLint v10 no longer accepts a 4th array element (the trailing mode string).
-// The valid schema is [severity, mode?, options?] — a 4th element is rejected.
-// Before: ["error", "always", {}, "as-needed"]
-// After:  ["error", "always", {}]
-// Pattern: severity , mode_string , options_object , extra_mode_string ]
-// Options object pattern handles one level of nesting: { generators: { mode: 'strict' } }
-const FUNC_NAMES_RE =
-  /(['"`]func-names['"`]\s*:\s*\[)(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)?\})\s*,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*(\])/g
+const RADIX_AS_NEEDED_TODO =
+  '/* TODO: "as-needed" is removed in ESLint v10 — remove the "as-needed" option or disable the rule */'
 
-// no-invalid-regexp: ESLint v10 rejects duplicate flags in allowConstructorFlags.
-// Before: { allowConstructorFlags: ["u", "y", "u"] }
-// After:  { allowConstructorFlags: ["u", "y"] }
-const ALLOW_CONSTRUCTOR_FLAGS_RE = /allowConstructorFlags\s*:\s*\[([^\]]+)\]/g
-
-// radix: string options "always" and "as-needed" are deprecated in v10.
-// "always" is the only effective behavior now, so it can be stripped.
-// Before: 'radix': ['error', 'always']
-// After:  'radix': 'error'
-const RADIX_ALWAYS_RE = /(['"`]radix['"`]\s*:\s*)\[(\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*),\s*(['"`])always\3\s*\]/g
-
-// "as-needed" changed behavior — flag with TODO.
-// Before: 'radix': ['error', 'as-needed']
-// After:  'radix': ['error', /* TODO */ 'as-needed']
-const RADIX_AS_NEEDED_RE = /(['"`]radix['"`]\s*:\s*\[\s*(?:'[^']*'|"[^"]*"|`[^`]*`|\d+)\s*)(,\s*)(['"`])as-needed\3/g
-
-function deduplicateFlags(match: string, inner: string): string {
-  const flags = inner.match(/['"`][^'"`]*['"`]/g) ?? []
-  const seen = new Set<string>()
-  const unique = flags.filter((f) => {
-    const key = f.replaceAll(/['"` ]/g, '')
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
-  if (unique.length === flags.length) return match
-  return `allowConstructorFlags: [${unique.join(', ')}]`
+// Named (non-punctuation) children of a node
+function namedChildren(node: SgNode<JS>): SgNode<JS>[] {
+  return node.children().filter((c) => c.isNamed())
 }
 
 export default async function transform(root: SgRoot<JS>): Promise<string | null> {
-  const source = root.root().text()
-  let result = source
+  const rootNode = root.root()
+  const edits: Edit[] = []
 
-  // 1. Remove extra 4th element from func-names array config
-  result = result.replaceAll(FUNC_NAMES_RE, (_match, open, body, close) => `${open}${body}${close}`)
+  // ── 1. func-names: Remove extra 4th string element ──────────────────────────
+  // ESLint v10 no longer accepts [severity, mode, options, extraMode]; strip extraMode.
+  for (const pair of rootNode.findAll({
+    rule: { kind: 'pair', has: { field: 'key', regex: 'func-names' } },
+  })) {
+    const arrayNode = pair.find({ rule: { kind: 'array' } })
+    if (!arrayNode) continue
 
-  // 2. Deduplicate allowConstructorFlags in no-invalid-regexp
-  result = result.replaceAll(ALLOW_CONSTRUCTOR_FLAGS_RE, deduplicateFlags)
+    const elems = namedChildren(arrayNode)
+    // Must have at least 4 elements, and the 3rd (index 2) must be the options object
+    if (elems.length < 4 || elems[2]?.kind() !== 'object') continue
 
-  // 3. radix "always": strip the redundant option (default behavior in v10)
-  result = result.replaceAll(
-    RADIX_ALWAYS_RE,
-    (_: string, prefix: string, severity: string) => `${prefix}${severity.trim()}`,
-  )
+    // Remove the trailing string element from the local array text to avoid
+    // navigating tree-sitter sibling commas
+    const arrayText = arrayNode.text()
+    const trailingStringRe = /,\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*\]$/
+    const match = arrayText.match(trailingStringRe)
+    if (!match) continue
 
-  // 4. radix "as-needed": flag with TODO — the option is deprecated and behavior changed
-  result = result.replaceAll(
-    RADIX_AS_NEEDED_RE,
-    (_: string, open: string, sep: string, q: string) =>
-      `${open}${sep}/* TODO: "as-needed" is removed in ESLint v10 — remove the "as-needed" option or disable the rule */ ${q}as-needed${q}`,
-  )
+    const { start, end } = arrayNode.range()
+    edits.push({
+      startPos: start.index,
+      endPos: end.index,
+      insertedText: `${arrayText.slice(0, arrayText.length - match[0].length)}]`,
+    })
+  }
 
-  return result === source ? null : result
+  // ── 2. no-invalid-regexp: Deduplicate allowConstructorFlags values ────────────
+  // ESLint v10 rejects duplicate flags; keep only the first occurrence of each.
+  for (const pair of rootNode.findAll({
+    rule: { kind: 'pair', has: { field: 'key', regex: 'allowConstructorFlags' } },
+  })) {
+    const arrayNode = pair.find({ rule: { kind: 'array' } })
+    if (!arrayNode) continue
+
+    const stringElems = namedChildren(arrayNode).filter((e) => e.kind() === 'string')
+    const seen = new Set<string>()
+    const uniqueElems: SgNode<JS>[] = []
+    for (const elem of stringElems) {
+      const flag = elem.text().replaceAll(/['"` ]/g, '')
+      if (!seen.has(flag)) {
+        seen.add(flag)
+        uniqueElems.push(elem)
+      }
+    }
+
+    if (uniqueElems.length < stringElems.length) {
+      const { start, end } = arrayNode.range()
+      edits.push({
+        startPos: start.index,
+        endPos: end.index,
+        insertedText: `[${uniqueElems.map((e) => e.text()).join(', ')}]`,
+      })
+    }
+  }
+
+  // ── 3. radix: Handle deprecated 'always' and 'as-needed' options ─────────────
+  for (const pair of rootNode.findAll({
+    rule: { kind: 'pair', has: { field: 'key', regex: 'radix' } },
+  })) {
+    const arrayNode = pair.find({ rule: { kind: 'array' } })
+    if (!arrayNode) continue
+
+    const elems = namedChildren(arrayNode)
+    const severity = elems[0]
+    const option = elems[1]
+    if (!severity || option?.kind() !== 'string') continue
+
+    const optionVal = option.text().replaceAll(/['"` ]/g, '')
+
+    if (optionVal === 'always') {
+      // ['error', 'always'] → 'error'  (strip redundant option; 'always' is the only v10 behavior)
+      const { start, end } = arrayNode.range()
+      edits.push({ startPos: start.index, endPos: end.index, insertedText: severity.text() })
+    } else if (optionVal === 'as-needed') {
+      // ['error', 'as-needed'] → ['error', /* TODO */ 'as-needed']
+      const insertPos = option.range().start.index
+      edits.push({ startPos: insertPos, endPos: insertPos, insertedText: `${RADIX_AS_NEEDED_TODO} ` })
+    }
+  }
+
+  if (edits.length === 0) return null
+  return rootNode.commitEdits(edits)
 }

--- a/codemods/v10/linter-api/scripts/fix-rule-options.ts
+++ b/codemods/v10/linter-api/scripts/fix-rule-options.ts
@@ -58,7 +58,7 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
   result = result.replaceAll(
     RADIX_AS_NEEDED_RE,
     (_: string, open: string, sep: string, q: string) =>
-      `${open}${sep}/* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ ${q}as-needed${q}`,
+      `${open}${sep}/* TODO: "as-needed" is removed in ESLint v10 — remove the "as-needed" option or disable the rule */ ${q}as-needed${q}`,
   )
 
   return result === source ? null : result

--- a/codemods/v10/linter-api/tests/eslint-flags/expected.js
+++ b/codemods/v10/linter-api/tests/eslint-flags/expected.js
@@ -1,0 +1,11 @@
+import { ESLint } from 'eslint'
+
+// Removed flags should be stripped
+const eslint1 = new ESLint({ flags: [] })
+const eslint2 = new ESLint({ flags: [] })
+const eslint3 = new ESLint({ flags: [] })
+const eslint4 = new ESLint({ flags: [], fix: true })
+
+// Unrelated flags — must not be touched
+const eslint5 = new ESLint({ flags: ['some_other_flag'] })
+const eslint6 = new ESLint({ flags: [] })

--- a/codemods/v10/linter-api/tests/eslint-flags/input.js
+++ b/codemods/v10/linter-api/tests/eslint-flags/input.js
@@ -1,0 +1,11 @@
+import { ESLint } from 'eslint'
+
+// Removed flags should be stripped
+const eslint1 = new ESLint({ flags: ['v10_config_lookup_from_file'] })
+const eslint2 = new ESLint({ flags: ['unstable_config_lookup_from_file'] })
+const eslint3 = new ESLint({ flags: ['v10_config_lookup_from_file', 'unstable_config_lookup_from_file'] })
+const eslint4 = new ESLint({ flags: ['v10_config_lookup_from_file'], fix: true })
+
+// Unrelated flags — must not be touched
+const eslint5 = new ESLint({ flags: ['some_other_flag'] })
+const eslint6 = new ESLint({ flags: [] })

--- a/codemods/v10/linter-api/tests/lint-message-nodetype/expected.js
+++ b/codemods/v10/linter-api/tests/lint-message-nodetype/expected.js
@@ -1,0 +1,32 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+const messages = linter.verify(code, config)
+
+// nodeType as a trailing property
+assert.deepEqual(messages[0], {
+  ruleId: 'no-var',
+  severity: 2,
+  message: 'Unexpected var, use let or const instead.',
+})
+
+// nodeType as a leading property
+assert.deepEqual(messages[0], {
+  message: 'some error',
+  line: 1,
+})
+
+// nodeType as the only property
+assert.deepEqual(messages[0], {  })
+
+// nodeType in a nested array of expected messages
+assert.deepEqual(messages, [
+  { message: 'error 1', line: 1 },
+  { message: 'error 2', line: 2 },
+])
+
+// member expression accesses — flagged with TODO
+const type = messages[0].nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */
+if (messages[0].nodeType /* TODO: LintMessage.nodeType was removed in ESLint v10 — remove this usage */ === 'Identifier') {
+  console.log('identifier')
+}

--- a/codemods/v10/linter-api/tests/lint-message-nodetype/input.js
+++ b/codemods/v10/linter-api/tests/lint-message-nodetype/input.js
@@ -1,0 +1,34 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+const messages = linter.verify(code, config)
+
+// nodeType as a trailing property
+assert.deepEqual(messages[0], {
+  ruleId: 'no-var',
+  severity: 2,
+  message: 'Unexpected var, use let or const instead.',
+  nodeType: 'VariableDeclaration',
+})
+
+// nodeType as a leading property
+assert.deepEqual(messages[0], {
+  nodeType: 'ExpressionStatement',
+  message: 'some error',
+  line: 1,
+})
+
+// nodeType as the only property
+assert.deepEqual(messages[0], { nodeType: 'Identifier' })
+
+// nodeType in a nested array of expected messages
+assert.deepEqual(messages, [
+  { message: 'error 1', nodeType: 'Identifier', line: 1 },
+  { message: 'error 2', nodeType: 'CallExpression', line: 2 },
+])
+
+// member expression accesses — flagged with TODO
+const type = messages[0].nodeType
+if (messages[0].nodeType === 'Identifier') {
+  console.log('identifier')
+}

--- a/codemods/v10/linter-api/tests/lint-message-non-eslint/expected.js
+++ b/codemods/v10/linter-api/tests/lint-message-non-eslint/expected.js
@@ -1,0 +1,10 @@
+// No eslint import — nodeType here belongs to an unrelated domain, should not be changed
+const astNode = {
+  type: 'Identifier',
+  nodeType: 'VariableDeclaration',
+  name: 'x',
+}
+
+function inspect(node) {
+  return node.nodeType
+}

--- a/codemods/v10/linter-api/tests/lint-message-non-eslint/input.js
+++ b/codemods/v10/linter-api/tests/lint-message-non-eslint/input.js
@@ -1,0 +1,10 @@
+// No eslint import — nodeType here belongs to an unrelated domain, should not be changed
+const astNode = {
+  type: 'Identifier',
+  nodeType: 'VariableDeclaration',
+  name: 'x',
+}
+
+function inspect(node) {
+  return node.nodeType
+}

--- a/codemods/v10/linter-api/tests/lint-message-unrelated-object/expected.js
+++ b/codemods/v10/linter-api/tests/lint-message-unrelated-object/expected.js
@@ -1,0 +1,17 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+
+// This is an AST node from a custom parser — unrelated to LintMessage.
+// nodeType here should NOT be removed because the object has no LintMessage
+// sibling properties and is not used alongside a verify() result.
+const astNode = {
+  type: 'Identifier',
+  nodeType: 'VariableDeclaration',
+  name: 'x',
+}
+
+// Also not inside a call with a verify() sibling
+function buildNode(nodeType) {
+  return { nodeType, value: 42 }
+}

--- a/codemods/v10/linter-api/tests/lint-message-unrelated-object/input.js
+++ b/codemods/v10/linter-api/tests/lint-message-unrelated-object/input.js
@@ -1,0 +1,17 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+
+// This is an AST node from a custom parser — unrelated to LintMessage.
+// nodeType here should NOT be removed because the object has no LintMessage
+// sibling properties and is not used alongside a verify() result.
+const astNode = {
+  type: 'Identifier',
+  nodeType: 'VariableDeclaration',
+  name: 'x',
+}
+
+// Also not inside a call with a verify() sibling
+function buildNode(nodeType) {
+  return { nodeType, value: 42 }
+}

--- a/codemods/v10/linter-api/tests/linter-constructor-deprecated-methods/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-deprecated-methods/expected.js
@@ -1,0 +1,13 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+
+// All of these are removed in ESLint v10
+linter.defineParser(/* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint', require('babel-eslint'))
+linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
+linter.defineRules(/* TODO: defineRules() removed in ESLint v10, no replacement */ { 'rule-a': ruleA, 'rule-b': ruleB })
+const rules = linter.getRules(/* TODO: getRules() removed in ESLint v10, no replacement */ )
+
+// Normal method calls — must not be touched
+linter.verify(code, config)
+linter.verifyAndFix(code, config)

--- a/codemods/v10/linter-api/tests/linter-constructor-deprecated-methods/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-deprecated-methods/input.js
@@ -1,0 +1,13 @@
+import { Linter } from 'eslint'
+
+const linter = new Linter()
+
+// All of these are removed in ESLint v10
+linter.defineParser('babel-eslint', require('babel-eslint'))
+linter.defineRule('my-rule', myRule)
+linter.defineRules({ 'rule-a': ruleA, 'rule-b': ruleB })
+const rules = linter.getRules()
+
+// Normal method calls — must not be touched
+linter.verify(code, config)
+linter.verifyAndFix(code, config)

--- a/codemods/v10/linter-api/tests/linter-constructor-eslintrc/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-eslintrc/expected.js
@@ -1,0 +1,4 @@
+import { Linter } from 'eslint'
+
+// configType: 'eslintrc' is removed — add TODO
+const linter = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)

--- a/codemods/v10/linter-api/tests/linter-constructor-eslintrc/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-eslintrc/expected.js
@@ -2,3 +2,7 @@ import { Linter } from 'eslint'
 
 // configType: 'eslintrc' is removed — add TODO
 const linter = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+
+// configType: 'eslintrc' with additional options — remove configType, keep rest, add TODO
+const linterLeading = new Linter({ allowInlineConfig: false /* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */ })
+const linterTrailing = new Linter({ allowInlineConfig: false /* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */ })

--- a/codemods/v10/linter-api/tests/linter-constructor-eslintrc/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-eslintrc/input.js
@@ -2,3 +2,7 @@ import { Linter } from 'eslint'
 
 // configType: 'eslintrc' is removed — add TODO
 const linter = new Linter({ configType: 'eslintrc' })
+
+// configType: 'eslintrc' with additional options — remove configType, keep rest, add TODO
+const linterLeading = new Linter({ configType: 'eslintrc', allowInlineConfig: false })
+const linterTrailing = new Linter({ allowInlineConfig: false, configType: 'eslintrc' })

--- a/codemods/v10/linter-api/tests/linter-constructor-eslintrc/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-eslintrc/input.js
@@ -1,0 +1,4 @@
+import { Linter } from 'eslint'
+
+// configType: 'eslintrc' is removed — add TODO
+const linter = new Linter({ configType: 'eslintrc' })

--- a/codemods/v10/linter-api/tests/linter-constructor-flat/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-flat/expected.js
@@ -1,0 +1,10 @@
+import { Linter } from 'eslint'
+
+// configType: 'flat' is the default in v10 — just remove the option
+const linter1 = new Linter()
+const linter2 = new Linter({ allowInlineConfig: true })
+const linter5 = new Linter({ allowInlineConfig: true })
+
+// No configType — must not be touched
+const linter3 = new Linter()
+const linter4 = new Linter({ allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-flat/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-flat/input.js
@@ -1,0 +1,10 @@
+import { Linter } from 'eslint'
+
+// configType: 'flat' is the default in v10 — just remove the option
+const linter1 = new Linter({ configType: 'flat' })
+const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
+const linter5 = new Linter({ allowInlineConfig: true, configType: 'flat' })
+
+// No configType — must not be touched
+const linter3 = new Linter()
+const linter4 = new Linter({ allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-alias/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-alias/expected.js
@@ -1,0 +1,7 @@
+// ESM aliased import — the alias name is not matched by the current regex,
+// so new EslintLinter(...) is not transformed (current limitation)
+import { Linter as EslintLinter } from 'eslint'
+
+const linter1 = new EslintLinter({ configType: 'flat' })
+const linter2 = new EslintLinter({ configType: 'eslintrc' })
+const linter3 = new EslintLinter({ configType: 'flat', allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-alias/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-alias/input.js
@@ -1,0 +1,7 @@
+// ESM aliased import — the alias name is not matched by the current regex,
+// so new EslintLinter(...) is not transformed (current limitation)
+import { Linter as EslintLinter } from 'eslint'
+
+const linter1 = new EslintLinter({ configType: 'flat' })
+const linter2 = new EslintLinter({ configType: 'eslintrc' })
+const linter3 = new EslintLinter({ configType: 'flat', allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-cjs-property/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-cjs-property/expected.js
@@ -1,0 +1,11 @@
+// CJS namespace access — new eslint.Linter() uses a member expression,
+// which is not matched by the current regex (current limitation)
+const eslint = require('eslint')
+const linter1 = new eslint.Linter({ configType: 'flat' })
+const linter2 = new eslint.Linter({ configType: 'eslintrc' })
+
+// CJS property extraction — Linter is bound to the same name, so it IS matched
+const Linter = require('eslint').Linter
+const linter3 = new Linter()
+const linter4 = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+const linter5 = new Linter({ allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-cjs-property/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-cjs-property/input.js
@@ -1,0 +1,11 @@
+// CJS namespace access — new eslint.Linter() uses a member expression,
+// which is not matched by the current regex (current limitation)
+const eslint = require('eslint')
+const linter1 = new eslint.Linter({ configType: 'flat' })
+const linter2 = new eslint.Linter({ configType: 'eslintrc' })
+
+// CJS property extraction — Linter is bound to the same name, so it IS matched
+const Linter = require('eslint').Linter
+const linter3 = new Linter({ configType: 'flat' })
+const linter4 = new Linter({ configType: 'eslintrc' })
+const linter5 = new Linter({ configType: 'flat', allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-cjs/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-cjs/expected.js
@@ -1,0 +1,14 @@
+const { Linter } = require('eslint')
+
+// configType: 'flat' is the default in v10 — remove it
+const linter1 = new Linter()
+const linter2 = new Linter({ allowInlineConfig: true })
+const linter3 = new Linter({ allowInlineConfig: true })
+
+// configType: 'eslintrc' is removed — add TODO
+const linter4 = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+const linter5 = new Linter({ allowInlineConfig: false /* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */ })
+
+// No configType — must not be touched
+const linter6 = new Linter()
+const linter7 = new Linter({ allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-cjs/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-cjs/input.js
@@ -1,0 +1,14 @@
+const { Linter } = require('eslint')
+
+// configType: 'flat' is the default in v10 — remove it
+const linter1 = new Linter({ configType: 'flat' })
+const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
+const linter3 = new Linter({ allowInlineConfig: true, configType: 'flat' })
+
+// configType: 'eslintrc' is removed — add TODO
+const linter4 = new Linter({ configType: 'eslintrc' })
+const linter5 = new Linter({ configType: 'eslintrc', allowInlineConfig: false })
+
+// No configType — must not be touched
+const linter6 = new Linter()
+const linter7 = new Linter({ allowInlineConfig: true })

--- a/codemods/v10/linter-api/tests/linter-constructor-import-dynamic/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-dynamic/expected.js
@@ -1,0 +1,11 @@
+// Dynamic import with await — destructured name matches, so it is transformed
+const { Linter } = await import('eslint')
+const linter1 = new Linter()
+const linter2 = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
+const linter3 = new Linter({ allowInlineConfig: true })
+
+// Dynamic import via .then() with a renamed binding — the alias is not matched,
+// so new EslintLinter(...) is not transformed (current limitation)
+import('eslint').then(({ Linter: EslintLinter }) => {
+  const linter4 = new EslintLinter({ configType: 'flat' })
+})

--- a/codemods/v10/linter-api/tests/linter-constructor-import-dynamic/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-import-dynamic/input.js
@@ -1,0 +1,11 @@
+// Dynamic import with await — destructured name matches, so it is transformed
+const { Linter } = await import('eslint')
+const linter1 = new Linter({ configType: 'flat' })
+const linter2 = new Linter({ configType: 'eslintrc' })
+const linter3 = new Linter({ configType: 'flat', allowInlineConfig: true })
+
+// Dynamic import via .then() with a renamed binding — the alias is not matched,
+// so new EslintLinter(...) is not transformed (current limitation)
+import('eslint').then(({ Linter: EslintLinter }) => {
+  const linter4 = new EslintLinter({ configType: 'flat' })
+})

--- a/codemods/v10/linter-api/tests/linter-constructor-load-eslint/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-load-eslint/expected.js
@@ -1,0 +1,8 @@
+import { loadESLint } from 'eslint'
+
+// useFlatConfig removed — loadESLint() uses flat config by default in v10
+const ESLintFlat = await loadESLint()
+const ESLintLegacy = await loadESLint()
+
+// No useFlatConfig — must not be touched
+const ESLint = await loadESLint()

--- a/codemods/v10/linter-api/tests/linter-constructor-load-eslint/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-load-eslint/expected.js
@@ -4,5 +4,9 @@ import { loadESLint } from 'eslint'
 const ESLintFlat = await loadESLint()
 const ESLintLegacy = await loadESLint()
 
+// useFlatConfig with additional options — remove only useFlatConfig, keep the rest
+const ESLintFlatLeading = await loadESLint({ cwd: '/path' })
+const ESLintFlatTrailing = await loadESLint({ cwd: '/path' })
+
 // No useFlatConfig — must not be touched
 const ESLint = await loadESLint()

--- a/codemods/v10/linter-api/tests/linter-constructor-load-eslint/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-load-eslint/input.js
@@ -1,0 +1,8 @@
+import { loadESLint } from 'eslint'
+
+// useFlatConfig removed — loadESLint() uses flat config by default in v10
+const ESLintFlat = await loadESLint({ useFlatConfig: true })
+const ESLintLegacy = await loadESLint({ useFlatConfig: false })
+
+// No useFlatConfig — must not be touched
+const ESLint = await loadESLint()

--- a/codemods/v10/linter-api/tests/linter-constructor-load-eslint/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-load-eslint/input.js
@@ -4,5 +4,9 @@ import { loadESLint } from 'eslint'
 const ESLintFlat = await loadESLint({ useFlatConfig: true })
 const ESLintLegacy = await loadESLint({ useFlatConfig: false })
 
+// useFlatConfig with additional options — remove only useFlatConfig, keep the rest
+const ESLintFlatLeading = await loadESLint({ useFlatConfig: true, cwd: '/path' })
+const ESLintFlatTrailing = await loadESLint({ cwd: '/path', useFlatConfig: false })
+
 // No useFlatConfig — must not be touched
 const ESLint = await loadESLint()

--- a/codemods/v10/linter-api/tests/linter-constructor-non-eslint/expected.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-non-eslint/expected.js
@@ -1,0 +1,10 @@
+// configType on plain objects and arbitrary function calls — should not be changed
+const opts = { configType: 'flat' }
+configure({ configType: 'flat' })
+setup({ configType: 'eslintrc', allowInlineConfig: true })
+
+// Non-Linter class names with same property — should not be changed
+const config1 = new Configuration({ configType: 'flat' })
+const config2 = new MyLinter({ configType: 'flat' })
+const config3 = new BabelLinter({ configType: 'eslintrc' })
+const config4 = new TSLinter({ configType: 'flat', allowInlineConfig: false })

--- a/codemods/v10/linter-api/tests/linter-constructor-non-eslint/input.js
+++ b/codemods/v10/linter-api/tests/linter-constructor-non-eslint/input.js
@@ -1,0 +1,10 @@
+// configType on plain objects and arbitrary function calls — should not be changed
+const opts = { configType: 'flat' }
+configure({ configType: 'flat' })
+setup({ configType: 'eslintrc', allowInlineConfig: true })
+
+// Non-Linter class names with same property — should not be changed
+const config1 = new Configuration({ configType: 'flat' })
+const config2 = new MyLinter({ configType: 'flat' })
+const config3 = new BabelLinter({ configType: 'eslintrc' })
+const config4 = new TSLinter({ configType: 'flat', allowInlineConfig: false })

--- a/codemods/v10/linter-api/tests/rule-options-func-names/expected.js
+++ b/codemods/v10/linter-api/tests/rule-options-func-names/expected.js
@@ -5,6 +5,10 @@ export default [
       'func-names': ['error', 'always', {}],
       'func-names': ['warn', 'as-needed', {}],
       'func-names': [2, 'always', {}],
+      // Non-empty options object (flat) — 4th element still removed
+      'func-names': ['error', 'always', { generators: 'as-needed' }],
+      // Nested options object — 4th element still removed
+      'func-names': ['error', 'always', { generators: { mode: 'strict' } }],
       // Only 3 elements — must not be touched
       'func-names': ['error', 'always', {}],
       // Only severity — must not be touched

--- a/codemods/v10/linter-api/tests/rule-options-func-names/expected.js
+++ b/codemods/v10/linter-api/tests/rule-options-func-names/expected.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    rules: {
+      // Extra 4th element no longer accepted in v10
+      'func-names': ['error', 'always', {}],
+      'func-names': ['warn', 'as-needed', {}],
+      'func-names': [2, 'always', {}],
+      // Only 3 elements — must not be touched
+      'func-names': ['error', 'always', {}],
+      // Only severity — must not be touched
+      'func-names': 'error',
+    },
+  },
+]

--- a/codemods/v10/linter-api/tests/rule-options-func-names/input.js
+++ b/codemods/v10/linter-api/tests/rule-options-func-names/input.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    rules: {
+      // Extra 4th element no longer accepted in v10
+      'func-names': ['error', 'always', {}, 'as-needed'],
+      'func-names': ['warn', 'as-needed', {}, 'always'],
+      'func-names': [2, 'always', {}, 'never'],
+      // Only 3 elements — must not be touched
+      'func-names': ['error', 'always', {}],
+      // Only severity — must not be touched
+      'func-names': 'error',
+    },
+  },
+]

--- a/codemods/v10/linter-api/tests/rule-options-func-names/input.js
+++ b/codemods/v10/linter-api/tests/rule-options-func-names/input.js
@@ -5,6 +5,10 @@ export default [
       'func-names': ['error', 'always', {}, 'as-needed'],
       'func-names': ['warn', 'as-needed', {}, 'always'],
       'func-names': [2, 'always', {}, 'never'],
+      // Non-empty options object (flat) — 4th element still removed
+      'func-names': ['error', 'always', { generators: 'as-needed' }, 'never'],
+      // Nested options object — 4th element still removed
+      'func-names': ['error', 'always', { generators: { mode: 'strict' } }, 'never'],
       // Only 3 elements — must not be touched
       'func-names': ['error', 'always', {}],
       // Only severity — must not be touched

--- a/codemods/v10/linter-api/tests/rule-options-no-invalid-regexp/expected.js
+++ b/codemods/v10/linter-api/tests/rule-options-no-invalid-regexp/expected.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    rules: {
+      // Duplicate flags rejected in v10
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }],
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['g', 'i', 'm'] }],
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u'] }],
+      // No duplicates — must not be touched
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }],
+      // No options — must not be touched
+      'no-invalid-regexp': 'error',
+    },
+  },
+]

--- a/codemods/v10/linter-api/tests/rule-options-no-invalid-regexp/input.js
+++ b/codemods/v10/linter-api/tests/rule-options-no-invalid-regexp/input.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    rules: {
+      // Duplicate flags rejected in v10
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y', 'u'] }],
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['g', 'i', 'g', 'm'] }],
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'u', 'u'] }],
+      // No duplicates — must not be touched
+      'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }],
+      // No options — must not be touched
+      'no-invalid-regexp': 'error',
+    },
+  },
+]

--- a/codemods/v10/linter-api/tests/rule-options-radix/expected.js
+++ b/codemods/v10/linter-api/tests/rule-options-radix/expected.js
@@ -6,7 +6,7 @@ export default [
       'radix': 'warn',
       'radix': 2,
       // Deprecated "as-needed" — behavior changed, flag with TODO
-      'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed'],
+      'radix': ['error', /* TODO: "as-needed" is removed in ESLint v10 — remove the "as-needed" option or disable the rule */ 'as-needed'],
       // No string option — must not be touched
       'radix': 'error',
       'radix': ['error'],

--- a/codemods/v10/linter-api/tests/rule-options-radix/expected.js
+++ b/codemods/v10/linter-api/tests/rule-options-radix/expected.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    rules: {
+      // Deprecated "always" — safe to strip (this is the only effective behavior in v10)
+      'radix': 'error',
+      'radix': 'warn',
+      'radix': 2,
+      // Deprecated "as-needed" — behavior changed, flag with TODO
+      'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed'],
+      // No string option — must not be touched
+      'radix': 'error',
+      'radix': ['error'],
+    },
+  },
+]

--- a/codemods/v10/linter-api/tests/rule-options-radix/input.js
+++ b/codemods/v10/linter-api/tests/rule-options-radix/input.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    rules: {
+      // Deprecated "always" — safe to strip (this is the only effective behavior in v10)
+      'radix': ['error', 'always'],
+      'radix': ['warn', 'always'],
+      'radix': [2, 'always'],
+      // Deprecated "as-needed" — behavior changed, flag with TODO
+      'radix': ['error', 'as-needed'],
+      // No string option — must not be touched
+      'radix': 'error',
+      'radix': ['error'],
+    },
+  },
+]

--- a/codemods/v10/linter-api/tsconfig.json
+++ b/codemods/v10/linter-api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@codemod.com/jssg-types", "node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/codemods/v10/linter-api/workflow.yaml
+++ b/codemods/v10/linter-api/workflow.yaml
@@ -19,7 +19,7 @@ nodes:
             - '**/*.cjs'
             - '**/*.mjs'
       - id: fix-rule-options
-        name: 'Fix stricter func-names and no-invalid-regexp rule config schema'
+        name: 'Fix stricter rule config schema (func-names, no-invalid-regexp, radix)'
         depends_on:
           - fix-linter-constructor
         js-ast-grep:
@@ -31,4 +31,3 @@ nodes:
             - '**/*.jsx'
             - '**/*.cjs'
             - '**/*.mjs'
-            - '**/*.json'

--- a/codemods/v10/linter-api/workflow.yaml
+++ b/codemods/v10/linter-api/workflow.yaml
@@ -43,3 +43,22 @@ nodes:
             - '**/*.d.ts'
             - '**/*.d.mts'
             - '**/*.d.cts'
+      - id: fix-lint-message
+        name: 'Remove LintMessage.nodeType property from object literals'
+        depends_on:
+          - fix-rule-options
+        js-ast-grep:
+          js_file: scripts/fix-lint-message.ts
+          include:
+            - '**/*.js'
+            - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx'
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx'
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'

--- a/codemods/v10/linter-api/workflow.yaml
+++ b/codemods/v10/linter-api/workflow.yaml
@@ -12,12 +12,18 @@ nodes:
         js-ast-grep:
           js_file: scripts/fix-linter-constructor.ts
           include:
-            - '**/*.ts'
-            - '**/*.tsx'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx'
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx'
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'
       - id: fix-rule-options
         name: 'Fix stricter rule config schema (func-names, no-invalid-regexp, radix)'
         depends_on:
@@ -25,9 +31,15 @@ nodes:
         js-ast-grep:
           js_file: scripts/fix-rule-options.ts
           include:
-            - '**/*.ts'
-            - '**/*.tsx'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx'
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx'
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'

--- a/codemods/v10/linter-api/workflow.yaml
+++ b/codemods/v10/linter-api/workflow.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod/codemod/refs/heads/main/schemas/workflow.json
+
+version: '1'
+
+nodes:
+  - id: apply-transforms
+    name: Apply ESLint v9 to v10 Linter API Migration
+    type: automatic
+    steps:
+      - id: fix-linter-constructor
+        name: 'Fix removed Linter/ESLint constructor options'
+        js-ast-grep:
+          js_file: scripts/fix-linter-constructor.ts
+          include:
+            - '**/*.ts'
+            - '**/*.tsx'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'
+      - id: fix-rule-options
+        name: 'Fix stricter func-names and no-invalid-regexp rule config schema'
+        depends_on:
+          - fix-linter-constructor
+        js-ast-grep:
+          js_file: scripts/fix-rule-options.ts
+          include:
+            - '**/*.ts'
+            - '**/*.tsx'
+            - '**/*.js'
+            - '**/*.jsx'
+            - '**/*.cjs'
+            - '**/*.mjs'
+            - '**/*.json'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,18 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  codemods/v10/linter-api:
+    devDependencies:
+      '@codemod.com/jssg-types':
+        specifier: 'catalog:'
+        version: 1.6.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   codemods/v10/ruletester:
     devDependencies:
       '@codemod.com/jssg-types':


### PR DESCRIPTION
## Summary

ESLint v10 removes the `configType` option from the `Linter` constructor, the `useFlatConfig` option from `loadESLint`, two deprecated `flags` values from `new ESLint()`, and four deprecated `Linter` instance methods. It also tightens the schema for three built-in rules. Any consumer of these APIs will hit runtime errors or config validation failures after upgrading.

This PR adds a new codemod `@eslint/v9-to-v10-linter-api` that automatically migrates all of these breaking changes so developers can upgrade without touching affected code manually.

## What it transforms

**Remove `configType` from `new Linter()`**

```js
// Before
const linter = new Linter({ configType: 'flat' })
const linter2 = new Linter({ configType: 'flat', allowInlineConfig: true })
const legacy = new Linter({ configType: 'eslintrc' })

// After
const linter = new Linter()
const linter2 = new Linter({ allowInlineConfig: true })
const legacy = new Linter(/* TODO: configType "eslintrc" is removed in ESLint v10, flat config is now the only option */)
```

**Remove `useFlatConfig` from `loadESLint()`**

```js
// Before
const ESLintClass = await loadESLint({ useFlatConfig: true })

// After
const ESLintClass = await loadESLint()
```

**Remove removed flag values from `new ESLint({ flags: [...] })`**

```js
// Before
const eslint = new ESLint({ flags: ['v10_config_lookup_from_file'] })

// After
const eslint = new ESLint({ flags: [] })
```

**Deprecated `Linter` instance methods → TODO**

```js
// Before
linter.defineParser('babel-eslint', require('babel-eslint'))
linter.defineRule('my-rule', myRule)

// After
linter.defineParser(/* TODO: defineParser() removed in ESLint v10, no replacement */ 'babel-eslint', require('babel-eslint'))
linter.defineRule(/* TODO: defineRule() removed in ESLint v10, no replacement */ 'my-rule', myRule)
```

**`func-names` stricter schema — remove extra 4th element**

```js
// Before
'func-names': ['error', 'always', {}, 'as-needed']

// After
'func-names': ['error', 'always', {}]
```

**`no-invalid-regexp` — deduplicate `allowConstructorFlags`**

```js
// Before
'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y', 'u'] }]

// After
'no-invalid-regexp': ['error', { allowConstructorFlags: ['u', 'y'] }]
```

**`radix` — strip deprecated `"always"`, flag `"as-needed"` with TODO**

```js
// Before
'radix': ['error', 'always']
'radix': ['error', 'as-needed']

// After
'radix': 'error'
'radix': ['error', /* TODO: radix "as-needed" option is deprecated in ESLint v10 — the rule now always enforces providing the radix argument */ 'as-needed']
```

## How to use

```bash
npx codemod @eslint/v9-to-v10-linter-api
```

## Testing

8 fixtures covering all transform cases and edge conditions — including `configType` in leading, middle, and trailing positions; multi-flag arrays; numeric rule severities; all-duplicate `allowConstructorFlags` arrays; and `radix` string options.

59 scenarios validated in total (see [SCENARIOS-linter-api.md](https://github.com/khadatkarrohit/eslint-v9-ruletester-test/blob/main/SCENARIOS-linter-api.md)).

```bash
pnpm --filter @eslint/v9-to-v10-linter-api test
pnpm --filter @eslint/v9-to-v10-linter-api check-types
```

All tests pass.

## Related

- Companion to #8 (`@eslint/v9-to-v10-custom-rules`) and #9 (`@eslint/v9-to-v10-ruletester`) — together these three codemods cover all automatable ESLint v10 breaking changes
