### PR TITLE
fix: update `v8-v9` custom-rules workflow globs to include TS extension

### DIFF
--- a/.changeset/clever-pianos-film.md
+++ b/.changeset/clever-pianos-film.md
@@ -1,0 +1,5 @@
+---
+"@eslint/v8-to-v9-custom-rules": patch
+---
+
+fix: update custom-rules workflow globs to include TypeScript module extensions and exclude declaration files.

--- a/.changeset/clever-pianos-film.md
+++ b/.changeset/clever-pianos-film.md
@@ -1,5 +1,5 @@
 ---
-"@eslint/v8-to-v9-custom-rules": patch
+'@eslint/v8-to-v9-custom-rules': patch
 ---
 
 fix: update custom-rules workflow globs to include TypeScript module extensions and exclude declaration files.

--- a/codemods/v9/custom-rules/workflow.yaml
+++ b/codemods/v9/custom-rules/workflow.yaml
@@ -12,11 +12,18 @@ nodes:
         js-ast-grep:
           js_file: scripts/new-rule-format.ts
           include:
-            - '**/*.ts'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx' # Unlikely to be used for custom rules, but just in case
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx' # Unlikely to be used for custom rules, but just in case
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'
       - id: replace-context-methods
         name: 'Replace context methods'
         depends_on:
@@ -24,11 +31,18 @@ nodes:
         js-ast-grep:
           js_file: scripts/replace-context-method.ts
           include:
-            - '**/*.ts'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx' # Unlikely to be used for custom rules, but just in case
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx' # Unlikely to be used for custom rules, but just in case
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'
       - id: replace-current-statement
         name: 'Replace current statement'
         depends_on:
@@ -37,8 +51,15 @@ nodes:
         js-ast-grep:
           js_file: scripts/replace-current-statement.ts
           include:
-            - '**/*.ts'
             - '**/*.js'
-            - '**/*.jsx'
-            - '**/*.cjs'
             - '**/*.mjs'
+            - '**/*.cjs'
+            - '**/*.jsx' # Unlikely to be used for custom rules, but just in case
+            - '**/*.ts'
+            - '**/*.mts'
+            - '**/*.cts'
+            - '**/*.tsx' # Unlikely to be used for custom rules, but just in case
+          exclude:
+            - '**/*.d.ts'
+            - '**/*.d.mts'
+            - '**/*.d.cts'


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes an issue where `@eslint/v8-to-v9-custom-rules` did not catch some TS extensions such as `.mts` and `.cts`.

`.jsx` and `.tsx` are unusual extensions that are used by ESLint custom rules, but I included them intentionally just in case.

I’ve also excluded declaration file extensions such as `.d.ts`, `.d.mts`, and `.d.cts`, as they are not rule implementation files.

cc. @alexbit-codemod 

#### What changes did you make? (Give an overview)

Added the missing extensions to `codemods/v9/custom-rules/workflow.yaml`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A