### PR TITLE
fix: handle CRLF line endings in ignore files

### DIFF
--- a/.changeset/fix-ignore-file-crlf.md
+++ b/.changeset/fix-ignore-file-crlf.md
@@ -1,0 +1,5 @@
+---
+'@eslint/v8-to-v9-config': patch
+---
+
+fix: handle CRLF line endings in ignore files

--- a/codemods/v9/config-file/scripts/ignore-files.ts
+++ b/codemods/v9/config-file/scripts/ignore-files.ts
@@ -12,7 +12,7 @@ async function transform(root: SgRoot<JS>): Promise<string | null> {
   const release = acquireLock(stateKey)
   try {
     const beforeIgnoreFiles = getState<string[]>(stateKey) ?? []
-    let ignoreFiles = [...beforeIgnoreFiles, ...source.split('\n').filter((line) => line.trim() !== '')]
+    let ignoreFiles = [...beforeIgnoreFiles, ...source.split(/\r?\n/u).filter((line) => line.trim() !== '')]
     ignoreFiles = ignoreFiles
       .filter((file) => !file.startsWith('#'))
       .filter((file, index, self) => self.indexOf(file) === index)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes an issue in `@eslint/v8-to-v9-config` where the Windows line terminator, CRLF, is not correctly recognized as a valid line terminator in `.eslintignore` and `.gitignore`.

While ignore files can use POSIX LF and Windows CRLF, the current logic could only handle LF on POSIX, which could result in `\r` being included in the final ignore pattern when using `globalIgnores` in some cases.

FYI, this pattern is also used in the `rewrite` repository.

https://github.com/eslint/rewrite/blob/main/packages/config-helpers/src/ignore-file.js#L93

```js
const lines = ignoreFile.split(/\r?\n/u);
```

cc. @alexbit-codemod 

#### What changes did you make? (Give an overview)

Updated the regex to handle Windows CRLF.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I had planned to add a test for it, but it seems that [JSSG testing](https://docs.codemod.com/jssg/testing) does not allow unit testing and only supports fixture testing, and this repository doesn’t have a setup for dedicated unit tests. So I skipped it, but I’d be happy to set up unit testing in a follow-up PR if there’s demand for it.