### PR TITLE
fix: avoid duplicate node builtin helper imports

### DIFF
--- a/.changeset/quiet-timers-sing.md
+++ b/.changeset/quiet-timers-sing.md
@@ -2,4 +2,4 @@
 '@eslint/v8-to-v9-config': patch
 ---
 
-Recognize single-quoted and `node:`-prefixed builtin module specifiers when adding `__dirname` helper imports, preventing duplicate `path` imports for configs that already require `node:path` while emitting `node:url` and `node:path` helpers.
+Recognize single-quoted and `node:`-prefixed builtin module specifiers when adding `__dirname` helper imports, preventing duplicate `url`/`path` helper imports when configs already import from `node:url` or `node:path`.

--- a/.changeset/quiet-timers-sing.md
+++ b/.changeset/quiet-timers-sing.md
@@ -1,5 +1,5 @@
 ---
-"@eslint/v8-to-v9-config": patch
+'@eslint/v8-to-v9-config': patch
 ---
 
 Recognize single-quoted and `node:`-prefixed builtin module specifiers when adding `__dirname` helper imports, preventing duplicate `path` imports for configs that already require `node:path` while emitting `node:url` and `node:path` helpers.

--- a/.changeset/quiet-timers-sing.md
+++ b/.changeset/quiet-timers-sing.md
@@ -1,0 +1,5 @@
+---
+"@eslint/v8-to-v9-config": patch
+---
+
+Recognize single-quoted and `node:`-prefixed builtin module specifiers when adding `__dirname` helper imports, preventing duplicate `path` imports for configs that already require `node:path` while emitting `node:url` and `node:path` helpers.

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -6,9 +6,9 @@ function excludeLockfiles(files) {
 }
 
 export default {
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'oxfmt --write',
-  '*.{js,mjs,cjs,jsx}': 'oxlint --fix',
-  '*.{ts,mts,cts,tsx}': 'oxlint --type-aware --type-check --fix',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'oxfmt --write --no-error-on-unmatched-pattern',
+  '*.{js,mjs,cjs,jsx}': 'oxlint --fix --no-error-on-unmatched-pattern',
+  '*.{ts,mts,cts,tsx}': 'oxlint --type-aware --type-check --fix --no-error-on-unmatched-pattern',
   /** @param {string[]} files */
   '*.{json,yaml,yml}': (files) => {
     const filtered = excludeLockfiles(files)

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -6,7 +6,7 @@ function excludeLockfiles(files) {
 }
 
 export default {
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': 'oxfmt --write --no-error-on-unmatched-pattern',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'oxfmt --write --no-error-on-unmatched-pattern',
   '*.{js,mjs,cjs,jsx}': 'oxlint --fix --no-error-on-unmatched-pattern',
   '*.{ts,mts,cts,tsx}': 'oxlint --type-aware --type-check --fix --no-error-on-unmatched-pattern',
   /** @param {string[]} files */

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/expected.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/expected.js
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import { fileURLToPath } from "url";
 import path from "node:path";
 import { defineConfig } from "@eslint/config-helpers";
 

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/expected.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/expected.js
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { defineConfig } from "@eslint/config-helpers";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig([
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname
+      }
+    },
+  }
+]);

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/input.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-double-quote/input.js
@@ -1,0 +1,7 @@
+const path = require("node:path");
+
+module.exports = {
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/expected.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/expected.js
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import { fileURLToPath } from "url";
 import path from "node:path";
 import { defineConfig } from "@eslint/config-helpers";
 

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/expected.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/expected.js
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { defineConfig } from "@eslint/config-helpers";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig([
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname
+      }
+    },
+  }
+]);

--- a/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/input.js
+++ b/codemods/v9/config-file/tests/transform-eslintrc-javascript-with-node-prefix-and-single-quote/input.js
@@ -1,0 +1,7 @@
+const path = require('node:path');
+
+module.exports = {
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/codemods/v9/config-file/utils/make-new-config.ts
+++ b/codemods/v9/config-file/utils/make-new-config.ts
@@ -205,10 +205,10 @@ const makeNewConfig = (sectors: SectorData[], imports: string[], directory: stri
   if (needsDirname) {
     // Add imports for url and path modules (at the beginning)
     if (!imports.some((imp) => /\bfrom\s+(?<quote>["'])(?:node:)?url\k<quote>/.test(imp))) {
-      imports.unshift('import { fileURLToPath } from "node:url";')
+      imports.unshift('import { fileURLToPath } from "url";')
     }
     if (!imports.some((imp) => /\bfrom\s+(?<quote>["'])(?:node:)?path\k<quote>/.test(imp))) {
-      imports.unshift('import path from "node:path";')
+      imports.unshift('import path from "path";')
     }
   }
 

--- a/codemods/v9/config-file/utils/make-new-config.ts
+++ b/codemods/v9/config-file/utils/make-new-config.ts
@@ -204,11 +204,11 @@ const makeNewConfig = (sectors: SectorData[], imports: string[], directory: stri
 
   if (needsDirname) {
     // Add imports for url and path modules (at the beginning)
-    if (!imports.some((imp) => imp.includes('from "url"'))) {
-      imports.unshift('import { fileURLToPath } from "url";')
+    if (!imports.some((imp) => /\bfrom\s+(?<quote>["'])(?:node:)?url\k<quote>/.test(imp))) {
+      imports.unshift('import { fileURLToPath } from "node:url";')
     }
-    if (!imports.some((imp) => imp.includes('from "path"'))) {
-      imports.unshift('import path from "path";')
+    if (!imports.some((imp) => /\bfrom\s+(?<quote>["'])(?:node:)?path\k<quote>/.test(imp))) {
+      imports.unshift('import path from "node:path";')
     }
   }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes an issue in `@eslint/v8-to-v9-config` where duplicate helper import detection was too narrow. The previous check only matched exact double-quoted specifiers like `from "url"` and `from "path"`, so configs that already used single quotes or `node:`-prefixed built-in modules could receive duplicate imports.

#### What changes did you make? (Give an overview)

This PR updates the duplicate import detection to recognize both quote styles and `node:` specifiers, while ensuring the opening and closing quotes match.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Actually, the current fixture-based test approach can’t verify all edge cases in the tests. I’ll add a more robust one if the ongoing addition of the unit test runner is accepted.