### PR TITLE
fix: false positives and map-spread support in v10 codemods

### DIFF
--- a/.changeset/fix-custom-rules-and-ruletester.md
+++ b/.changeset/fix-custom-rules-and-ruletester.md
@@ -1,0 +1,22 @@
+---
+'@eslint/v9-to-v10-custom-rules': minor
+'@eslint/v9-to-v10-ruletester': minor
+---
+
+Fix false positives and missed patterns in custom-rules and ruletester codemods
+
+custom-rules:
+
+- Replace context methods (getSourceCode, getFilename, etc.) and parserOptions now only
+  apply to the ESLint rule `context` object — not to arbitrary utility/config objects
+  that happen to have the same property names
+- Ternary backward-compat guards (context.getMethod ? context.getMethod() : context.prop)
+  are now collapsed to the v10 property, matching the existing ?? fallback handling
+- Fix argument extraction for isSpaceBetweenTokens when the receiver is itself a call
+  expression (e.g. getSourceCode(context).isSpaceBetweenTokens(a, b))
+
+ruletester:
+
+- Remove top-level `type` from invalid test cases generated via array.map() spread
+  (e.g. `...cases.map(code => ({ type, code, errors }))`) — previously only direct
+  array members were handled

--- a/codemods/v10/custom-rules/scripts/replace-context-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-context-methods.ts
@@ -70,6 +70,26 @@ function getParserOptionsSelector(): RuleConfig<JS> {
   }
 }
 
+function getTernaryFallbackSelector(): RuleConfig<JS> {
+  // Matches: context.getFilename ? context.getFilename() : context.filename
+  // (ternary form of the backward-compat fallback pattern)
+  return {
+    rule: {
+      kind: 'ternary_expression',
+      has: {
+        kind: 'call_expression',
+        has: {
+          kind: 'member_expression',
+          has: {
+            kind: 'property_identifier',
+            regex: DEPRECATED_METHODS_REGEX,
+          },
+        },
+      },
+    },
+  }
+}
+
 function getParserPathSelector(): RuleConfig<JS> {
   return {
     rule: {
@@ -124,6 +144,30 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     fallbackEdits.push(expr.replace(left.text()))
   }
 
+  // ── Pass 1b: collapse ternary fallback patterns ───────────────────────
+  // context.getFilename ? context.getFilename() : context.filename → context.filename
+  // The ternary tests for the old method's existence then calls it;
+  // the else-branch is the new v10 property. Collapse to the else-branch.
+  for (const expr of rootNode.findAll(getTernaryFallbackSelector())) {
+    const namedChildren = expr.children().filter((c: SgNode<JS>) => c.isNamed())
+    if (namedChildren.length !== 3) continue
+
+    const [condition, consequence, alternative] = namedChildren as [SgNode<JS>, SgNode<JS>, SgNode<JS>]
+
+    // condition must be a simple member_expression for the deprecated method (no call)
+    if (condition.kind() !== 'member_expression') continue
+    const condProp = condition.children().find((c: SgNode<JS>) => c.kind() === 'property_identifier')
+    if (!condProp || !(condProp.text() in METHOD_TO_PROP)) continue
+
+    // consequence must be the call to that same method
+    if (consequence.kind() !== 'call_expression') continue
+    const consText = consequence.text()
+    if (!consText.includes(`.${condProp.text()}(`)) continue
+
+    // collapse entire ternary to the alternative (the new v10 prop)
+    fallbackEdits.push(expr.replace(alternative.text()))
+  }
+
   let text = rootNode.text()
   if (fallbackEdits.length > 0) {
     text = rootNode.commitEdits(fallbackEdits)
@@ -135,6 +179,8 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
 
   // ── Pass 2: method call → property access ─────────────────────────────
   // context.getFilename() → context.filename
+  // Guard: only replace on the ESLint rule context (named 'context' by convention).
+  // This avoids false positives on wrapper objects like `eslintUtil.getSourceCode()`.
   for (const call of updatedRoot.findAll(getMethodCallSelector())) {
     const memberExpr = call.find({ rule: { kind: 'member_expression' } })
     if (!memberExpr) continue
@@ -142,12 +188,16 @@ export default async function transform(root: SgRoot<JS>): Promise<string | null
     const prop = METHOD_TO_PROP[method]
     if (!prop) continue
     const src = getSourceObject(memberExpr)
+    if (src !== 'context' && !src.endsWith('.context')) continue
     mainEdits.push(call.replace(`${src}.${prop}`))
   }
 
   // ── Pass 3: context.parserOptions → context.languageOptions.parserOptions
+  // Guard: only replace on `context` — avoids false positives on config/test objects
+  // like `legacyConfig.parserOptions` or `test.parserOptions`.
   for (const memberExpr of updatedRoot.findAll(getParserOptionsSelector())) {
     const src = getSourceObject(memberExpr)
+    if (src !== 'context' && !src.endsWith('.context')) continue
     mainEdits.push(memberExpr.replace(`${src}.languageOptions.parserOptions`))
   }
 

--- a/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
+++ b/codemods/v10/custom-rules/scripts/replace-sourcecode-methods.ts
@@ -25,7 +25,10 @@ function getSelector(): RuleConfig<JS> {
 }
 
 function getCallArgs(call: SgNode<JS>): string[] {
-  const argsNode = call.find({ rule: { kind: 'arguments' } })
+  // Use children() not find() to avoid picking up the arguments of a nested
+  // call in the callee part. For `a(x).method(y, z)`, find() would return
+  // the inner `arguments` `(x)` instead of the outer `(y, z)`.
+  const argsNode = call.children().find((c: SgNode<JS>) => c.kind() === 'arguments') ?? null
   if (!argsNode) return []
   return argsNode
     .children()

--- a/codemods/v10/custom-rules/tests/context-fallback-cleanup/expected.js
+++ b/codemods/v10/custom-rules/tests/context-fallback-cleanup/expected.js
@@ -4,10 +4,14 @@ module.exports = {
   create(context) {
     return {
       Program() {
+        // ?? form (right side deprecated)
         const file = context.filename
         const phys = context.physicalFilename
         const cwd = context.cwd
         const src = context.sourceCode
+        // ternary form: context.METHOD ? context.METHOD() : context.PROP
+        const file2 = context.filename
+        const src2 = context.sourceCode
       },
     }
   },

--- a/codemods/v10/custom-rules/tests/context-fallback-cleanup/input.js
+++ b/codemods/v10/custom-rules/tests/context-fallback-cleanup/input.js
@@ -4,10 +4,14 @@ module.exports = {
   create(context) {
     return {
       Program() {
+        // ?? form (right side deprecated)
         const file = context.filename ?? context.getFilename()
         const phys = context.physicalFilename ?? context.getPhysicalFilename()
         const cwd = context.cwd ?? context.getCwd()
         const src = context.sourceCode ?? context.getSourceCode()
+        // ternary form: context.METHOD ? context.METHOD() : context.PROP
+        const file2 = context.getFilename ? context.getFilename() : context.filename
+        const src2 = context.getSourceCode ? context.getSourceCode() : context.sourceCode
       },
     }
   },

--- a/codemods/v10/custom-rules/tests/context-no-false-positive/expected.js
+++ b/codemods/v10/custom-rules/tests/context-no-false-positive/expected.js
@@ -1,0 +1,14 @@
+'use strict'
+
+// These are utility/wrapper objects — NOT the ESLint rule context.
+// The codemod must NOT replace method calls or parserOptions on them.
+
+const src = eslintUtil.getSourceCode(context)
+const file = utils.getFilename()
+const cwd = helpers.getCwd()
+const opts = legacyConfig.parserOptions
+
+// Accessing parserOptions on a non-context object should also be left alone.
+function buildOptions(config) {
+  return config.parserOptions
+}

--- a/codemods/v10/custom-rules/tests/context-no-false-positive/input.js
+++ b/codemods/v10/custom-rules/tests/context-no-false-positive/input.js
@@ -1,0 +1,14 @@
+'use strict'
+
+// These are utility/wrapper objects — NOT the ESLint rule context.
+// The codemod must NOT replace method calls or parserOptions on them.
+
+const src = eslintUtil.getSourceCode(context)
+const file = utils.getFilename()
+const cwd = helpers.getCwd()
+const opts = legacyConfig.parserOptions
+
+// Accessing parserOptions on a non-context object should also be left alone.
+function buildOptions(config) {
+  return config.parserOptions
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-call-in-callee/expected.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-call-in-callee/expected.js
@@ -1,0 +1,18 @@
+'use strict'
+
+// isSpaceBetweenTokens where the receiver is itself a call expression.
+// E.g., eslint-plugin-react pattern: getSourceCode(context).isSpaceBetweenTokens(a, b)
+// The codemod must pass through a and b, not the inner argument (context).
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      JSXOpeningElement(node) {
+        const leftToken = sourceCode.getLastToken(node)
+        const rightToken = sourceCode.getFirstToken(node)
+        const adjacent = !getSourceCode(context).isSpaceBetween(leftToken, rightToken)
+        const spaced = getSourceCode(context).isSpaceBetween(leftToken, rightToken)
+      },
+    }
+  },
+}

--- a/codemods/v10/custom-rules/tests/sourcecode-call-in-callee/input.js
+++ b/codemods/v10/custom-rules/tests/sourcecode-call-in-callee/input.js
@@ -1,0 +1,18 @@
+'use strict'
+
+// isSpaceBetweenTokens where the receiver is itself a call expression.
+// E.g., eslint-plugin-react pattern: getSourceCode(context).isSpaceBetweenTokens(a, b)
+// The codemod must pass through a and b, not the inner argument (context).
+module.exports = {
+  create(context) {
+    const sourceCode = context.sourceCode
+    return {
+      JSXOpeningElement(node) {
+        const leftToken = sourceCode.getLastToken(node)
+        const rightToken = sourceCode.getFirstToken(node)
+        const adjacent = !getSourceCode(context).isSpaceBetweenTokens(leftToken, rightToken)
+        const spaced = getSourceCode(context).isSpaceBetweenTokens(leftToken, rightToken)
+      },
+    }
+  },
+}

--- a/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
+++ b/codemods/v10/ruletester/scripts/cleanup-invalid-cases.ts
@@ -1,6 +1,83 @@
 import { type Edit, type RuleConfig, type SgNode, type SgRoot } from 'codemod:ast-grep'
 import type JS from 'codemod:ast-grep/langs/javascript'
 
+// ESLint v9 (flat-config mode) throws ConfigError when an invalid test case
+// carries a top-level `type` property, e.g.
+//
+//   { type: 'CallExpression', code: 'eval(x)', errors: [...] }
+//
+// This selector keys on `code` being a sibling property so it naturally
+// excludes error-matcher objects inside errors[] (those don't have `code`).
+//
+// Two forms of test-case object are supported:
+//   1. Direct array member: invalid: [{ type, code: 'str', errors }]
+//      The `code` property is a full `pair` node: code: 'str'.
+//
+//   2. Arrow-function spread: invalid: [...arr.map(code => ({ type, code, errors }))]
+//      The `code` property is a shorthand_property_identifier node.
+//
+// The discriminating `has` constraint therefore accepts either form.
+
+// Shared anchor: once we've found the `pair(invalid:)`, the ancestor chain
+// up to the `.run()` call is the same for both code-paths.
+const invalidPairAnchor = {
+  kind: 'pair',
+  has: {
+    kind: 'property_identifier',
+    regex: '^invalid$',
+  },
+  inside: {
+    kind: 'object',
+    inside: {
+      kind: 'arguments',
+      inside: {
+        kind: 'call_expression',
+        has: {
+          kind: 'member_expression',
+          has: {
+            kind: 'property_identifier',
+            regex: '^run$',
+          },
+        },
+      },
+    },
+  },
+} as const
+
+// Path A — test-case object directly in the `invalid: [...]` array.
+//   pair(type) → object → array → pair(invalid) → …
+const directArrayPath = {
+  kind: 'array',
+  inside: invalidPairAnchor,
+} as const
+
+// Path B — test-case object is the parenthesized body of an arrow function
+// spread into the `invalid: [...]` array, e.g.:
+//   ...arr.map((code) => ({ type, code, errors }))
+//
+//   pair(type) → object → parenthesized_expression → arrow_function →
+//   arguments → call_expression(.map) → spread_element →
+//   array → pair(invalid) → …
+const mapSpreadPath = {
+  kind: 'parenthesized_expression',
+  inside: {
+    kind: 'arrow_function',
+    inside: {
+      kind: 'arguments',
+      inside: {
+        kind: 'call_expression',
+        inside: {
+          kind: 'spread_element',
+          inside: {
+            kind: 'array',
+            inside: invalidPairAnchor,
+          },
+        },
+      },
+    },
+  },
+} as const
+
 const selector = {
   rule: {
     kind: 'pair',
@@ -10,44 +87,17 @@ const selector = {
     },
     inside: {
       kind: 'object',
+      // Discriminator: every invalid test-case object has a `code` property.
+      // Error-matcher objects inside errors[] do not — this naturally excludes them.
+      // Accept both full pair (`code: 'str'`) and shorthand (`code`) forms.
+      has: {
+        any: [
+          { kind: 'pair', has: { kind: 'property_identifier', regex: '^code$' } },
+          { kind: 'shorthand_property_identifier', regex: '^code$' },
+        ],
+      },
       inside: {
-        kind: 'array',
-        inside: {
-          kind: 'pair',
-          has: {
-            kind: 'property_identifier',
-            regex: '^errors$',
-          },
-          inside: {
-            kind: 'object',
-            inside: {
-              kind: 'array',
-              inside: {
-                kind: 'pair',
-                has: {
-                  kind: 'property_identifier',
-                  regex: '^invalid$',
-                },
-                inside: {
-                  kind: 'object',
-                  inside: {
-                    kind: 'arguments',
-                    inside: {
-                      kind: 'call_expression',
-                      has: {
-                        kind: 'member_expression',
-                        has: {
-                          kind: 'property_identifier',
-                          regex: '^run$',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
+        any: [directArrayPath, mapSpreadPath],
       },
     },
   },

--- a/codemods/v10/ruletester/tests/cleanup-invalid-map-spread/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-map-spread/expected.js
@@ -1,0 +1,34 @@
+// Real pattern from eslint-plugin-import and eslint-plugin-promise:
+// test cases generated via array.map() spread into invalid: [].
+// The codemod must remove `type` from inside the map() callback object.
+ruleTester.run('my-rule', rule, {
+  valid: [],
+  invalid: [
+    // Direct object (baseline)
+    {
+      code: 'eval(x)',
+      errors: [{ messageId: 'noEval' }],
+    },
+
+    // map() spread -- type inside arrow-function-returned object
+    ...['eval(a)', 'eval(b)', 'eval(c)'].map((code) => ({
+      code,
+      errors: [{ messageId: 'noEval' }],
+    })),
+
+    // map() with index parameter
+    ...cases.map((code, i) => ({
+      code,
+      errors: [{ message: `Error ${i}` }],
+    })),
+
+    // No type -- must NOT be modified
+    { code: 'safe()', errors: [{ messageId: 'noSafe' }] },
+
+    // type inside errors[] inside map() -- must NOT be removed
+    ...errorCases.map((code) => ({
+      code,
+      errors: [{ messageId: 'err', type: 'CallExpression' }],
+    })),
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-map-spread/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-map-spread/input.js
@@ -1,0 +1,37 @@
+// Real pattern from eslint-plugin-import and eslint-plugin-promise:
+// test cases generated via array.map() spread into invalid: [].
+// The codemod must remove `type` from inside the map() callback object.
+ruleTester.run('my-rule', rule, {
+  valid: [],
+  invalid: [
+    // Direct object (baseline)
+    {
+      type: 'CallExpression',
+      code: 'eval(x)',
+      errors: [{ messageId: 'noEval' }],
+    },
+
+    // map() spread -- type inside arrow-function-returned object
+    ...['eval(a)', 'eval(b)', 'eval(c)'].map((code) => ({
+      type: 'CallExpression',
+      code,
+      errors: [{ messageId: 'noEval' }],
+    })),
+
+    // map() with index parameter
+    ...cases.map((code, i) => ({
+      type: 'Identifier',
+      code,
+      errors: [{ message: `Error ${i}` }],
+    })),
+
+    // No type -- must NOT be modified
+    { code: 'safe()', errors: [{ messageId: 'noSafe' }] },
+
+    // type inside errors[] inside map() -- must NOT be removed
+    ...errorCases.map((code) => ({
+      code,
+      errors: [{ messageId: 'err', type: 'CallExpression' }],
+    })),
+  ],
+})

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/expected.js
@@ -1,13 +1,22 @@
-// type inside errors[] is removed; type in valid cases or unrelated objects is not touched
+// type inside errors[] is a valid node-type assertion and must NOT be removed.
+// type in options must not be touched.
+// Only top-level type on the invalid test case itself is removed.
 ruleTester.run('my-rule', rule, {
   valid: [
-    // type in valid cases must not be touched (different script handles valid cases)
+    // type in options -- must not be touched
     { code: 'foo', options: [{ type: 'bar' }] },
   ],
   invalid: [
-    // type inside errors[] must be removed
+    // top-level type -- removed
     { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
-    // type in options must not be touched
-    { code: 'eval(y)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
+    // type inside errors[] -- must NOT be removed (valid node assertion in v9)
+    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // type in options -- must not be touched
+    { code: 'eval(z)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
+    // top-level type + type inside errors[] -- only top-level removed
+    {
+      code: 'eval(w)',
+      errors: [{ messageId: 'noEval', type: 'CallExpression' }],
+    },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-preserve-errors-type/input.js
@@ -1,13 +1,23 @@
-// type inside errors[] is removed; type in valid cases or unrelated objects is not touched
+// type inside errors[] is a valid node-type assertion and must NOT be removed.
+// type in options must not be touched.
+// Only top-level type on the invalid test case itself is removed.
 ruleTester.run('my-rule', rule, {
   valid: [
-    // type in valid cases must not be touched (different script handles valid cases)
+    // type in options -- must not be touched
     { code: 'foo', options: [{ type: 'bar' }] },
   ],
   invalid: [
-    // type inside errors[] must be removed
-    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    // type in options must not be touched
-    { code: 'eval(y)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
+    // top-level type -- removed
+    { type: 'CallExpression', code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
+    // type inside errors[] -- must NOT be removed (valid node assertion in v9)
+    { code: 'eval(y)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // type in options -- must not be touched
+    { code: 'eval(z)', options: [{ type: 'something' }], errors: [{ messageId: 'noEval' }] },
+    // top-level type + type inside errors[] -- only top-level removed
+    {
+      type: 'CallExpression',
+      code: 'eval(w)',
+      errors: [{ messageId: 'noEval', type: 'CallExpression' }],
+    },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/expected.js
@@ -1,14 +1,19 @@
 ruleTester.run('my-rule', rule, {
   invalid: [
+    // top-level type as first property (trailing comma path)
     { code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
-    { code: 'with(x) {}', errors: [{ messageId: 'noWith' }] },
-    { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+    // top-level type in the middle
+    { code: 'eval(y)', errors: [{ messageId: 'noEval' }] },
+    // top-level type as last property (preceding comma path)
+    { code: 'eval(z)', errors: [{ messageId: 'noEval' }] },
+    // no top-level type -- must not be changed
+    { code: 'eval(w)', errors: [{ messageId: 'noEval' }] },
+    // type inside errors[] -- must NOT be touched (node-type assertion, valid in v9)
+    { code: 'eval(v)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // multiline with top-level type
     {
-      code: 'eval(g)',
-      errors: [
-        { messageId: 'noEval' },
-        { messageId: 'noEval' },
-      ],
+      code: 'eval(a)',
+      errors: [{ messageId: 'noEval' }],
     },
   ],
 })

--- a/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
+++ b/codemods/v10/ruletester/tests/cleanup-invalid-type-prop/input.js
@@ -1,14 +1,20 @@
 ruleTester.run('my-rule', rule, {
   invalid: [
-    { code: 'eval(x)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
-    { code: 'with(x) {}', errors: [{ messageId: 'noWith', type: 'WithStatement' }] },
-    { code: 'delete y', errors: [{ messageId: 'noDelete' }] },
+    // top-level type as first property (trailing comma path)
+    { type: 'CallExpression', code: 'eval(x)', errors: [{ messageId: 'noEval' }] },
+    // top-level type in the middle
+    { code: 'eval(y)', type: 'CallExpression', errors: [{ messageId: 'noEval' }] },
+    // top-level type as last property (preceding comma path)
+    { code: 'eval(z)', errors: [{ messageId: 'noEval' }], type: 'CallExpression' },
+    // no top-level type -- must not be changed
+    { code: 'eval(w)', errors: [{ messageId: 'noEval' }] },
+    // type inside errors[] -- must NOT be touched (node-type assertion, valid in v9)
+    { code: 'eval(v)', errors: [{ messageId: 'noEval', type: 'CallExpression' }] },
+    // multiline with top-level type
     {
-      code: 'eval(g)',
-      errors: [
-        { messageId: 'noEval', type: 'CallExpression' },
-        { messageId: 'noEval' },
-      ],
+      type: 'CallExpression',
+      code: 'eval(a)',
+      errors: [{ messageId: 'noEval' }],
     },
   ],
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.12",
-    "codemod": "^1.11.0",
+    "codemod": "^1.12.3",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "markdown-link-check": "^3.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^2.27.12
         version: 2.31.0(@types/node@24.12.4)
       codemod:
-        specifier: ^1.11.0
-        version: 1.11.0
+        specifier: ^1.12.3
+        version: 1.12.3
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -196,32 +196,32 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codemod.com/cli-darwin-arm64@1.11.0':
-    resolution: {integrity: sha512-aVR6rn8eIYp2ZQMpmp7+Jpofotg4F8bKslLCtSfNalJ6EldjMtDCpLBU+q909cScgUYpdNVYG5vDHfydO9ZTDA==}
+  '@codemod.com/cli-darwin-arm64@1.12.3':
+    resolution: {integrity: sha512-AN6NmKl0QHTKDIrINXQr8s9kepjULhUThsZbviQZ3RTLs35OtGeJDh+L/4jkavNrhGIDLyN8KNdhTsGBBVb53A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@codemod.com/cli-darwin-x64@1.11.0':
-    resolution: {integrity: sha512-po22ocR1zXu+c/9+ATkciWsov4Ulz9ESiI1WZqjuvHNBzXrNY53xfYOlSoWW6JN1bdHQkewfWbUwP9nBqQW3AQ==}
+  '@codemod.com/cli-darwin-x64@1.12.3':
+    resolution: {integrity: sha512-Ag5VQZc6vnoPwpQq3JEqaDtjc5vnXM339p5bAiJFF6/gq25W6pl0qsgr5OOL4s8Ct49t1BbQzbMxf1Y2z7LduQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@codemod.com/cli-linux-arm64-gnu@1.11.0':
-    resolution: {integrity: sha512-Hcgli3wu7nnyvNCJDcg0+Y5T5NvGdnKyjOW5XfH28YUHzOCBkPmskq48E2n0mSA23pf0LOTqiPDx0MMgirnVXQ==}
+  '@codemod.com/cli-linux-arm64-gnu@1.12.3':
+    resolution: {integrity: sha512-/p+oqY9bqBg899G9FZHFlOQ80371lq9QKw2uQWha55Ln+Ozc5Ebz3M4VGn7vO9Y8+7RFOnDMpeJHzatP+l13yg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@codemod.com/cli-linux-x64-gnu@1.11.0':
-    resolution: {integrity: sha512-GMCvi40z9y65ZlNN1VNu6f97vg3JYHhdTI2ZUwiLE6uxMEJ5D2ZdAeQ8Y8O8pzJslrz+JnJNuzXaeXOXuknBYg==}
+  '@codemod.com/cli-linux-x64-gnu@1.12.3':
+    resolution: {integrity: sha512-9nobWgnAqlFF9gAQLeiNsiGJGiQ+G+ZJ7DlDmplLJTUFdQRElTNZV/lNa1fb9eLgW1q6QCQFErM25EKOurRn3w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@codemod.com/cli-win32-x64-msvc@1.11.0':
-    resolution: {integrity: sha512-wip/eBMPzq8ucuAPDcxELX0thw1vAEuyQNoTQws2m+pKtNj4+XXwkjqH2Wv5D9C57QFyrvHq16VbMYWXrG0Dug==}
+  '@codemod.com/cli-win32-x64-msvc@1.12.3':
+    resolution: {integrity: sha512-Z8tMg3/SxcKwQSbIc3GxofJt/70ygC31Qxv5i4/+S6Kw8CWRpUGS6LLhkbgjZJfex/bLE5nQD328kv6fEYXXnQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -623,8 +623,8 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
-  codemod@1.11.0:
-    resolution: {integrity: sha512-oyeaad3Jn0RxZDxmRiKZ41+mkbj1EDTrz3fM+rV9sj6m+UPWKjkX+pzb1Ble9uhj4i6veg7po84PdEQbdL88gQ==}
+  codemod@1.12.3:
+    resolution: {integrity: sha512-/LMLkf2UDU3uHjUg+6PgIn0a4+scG2IvOPU/myhzg+tB7zlJouJIf6vj8LRYlsWlbFgC8iuBTT88FR464puE0A==}
     engines: {node: '>= 16.0.0'}
     hasBin: true
 
@@ -1380,19 +1380,19 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@codemod.com/cli-darwin-arm64@1.11.0':
+  '@codemod.com/cli-darwin-arm64@1.12.3':
     optional: true
 
-  '@codemod.com/cli-darwin-x64@1.11.0':
+  '@codemod.com/cli-darwin-x64@1.12.3':
     optional: true
 
-  '@codemod.com/cli-linux-arm64-gnu@1.11.0':
+  '@codemod.com/cli-linux-arm64-gnu@1.12.3':
     optional: true
 
-  '@codemod.com/cli-linux-x64-gnu@1.11.0':
+  '@codemod.com/cli-linux-x64-gnu@1.12.3':
     optional: true
 
-  '@codemod.com/cli-win32-x64-msvc@1.11.0':
+  '@codemod.com/cli-win32-x64-msvc@1.12.3':
     optional: true
 
   '@codemod.com/jssg-types@1.6.1': {}
@@ -1672,15 +1672,15 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
-  codemod@1.11.0:
+  codemod@1.12.3:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@codemod.com/cli-darwin-arm64': 1.11.0
-      '@codemod.com/cli-darwin-x64': 1.11.0
-      '@codemod.com/cli-linux-arm64-gnu': 1.11.0
-      '@codemod.com/cli-linux-x64-gnu': 1.11.0
-      '@codemod.com/cli-win32-x64-msvc': 1.11.0
+      '@codemod.com/cli-darwin-arm64': 1.12.3
+      '@codemod.com/cli-darwin-x64': 1.12.3
+      '@codemod.com/cli-linux-arm64-gnu': 1.12.3
+      '@codemod.com/cli-linux-x64-gnu': 1.12.3
+      '@codemod.com/cli-win32-x64-msvc': 1.12.3
 
   commander@14.0.3: {}
 


### PR DESCRIPTION
## Why this PR

While validating the v9→v10 codemods against a real-world ESLint plugin (eslint-plugin-react), two codemods produced incorrect output — either transforming code they should not have touched (false positives) or missing a real migration pattern.

---

## `@eslint/v9-to-v10-custom-rules`

### Problem 1 — False positives: method rewrites applied to non-context objects

`context.getSourceCode()`, `context.getFilename()`, and `context.parserOptions` replacements were matching **any** object with those property names, not just the ESLint rule context. This caused wrong transformations like:

```js
// Wrong — eslintUtil is not the rule context
eslintUtil.getSourceCode(ctx)  →  eslintUtil.sourceCode
legacyConfig.parserOptions     →  legacyConfig.languageOptions.parserOptions
```

**Fix:** Added a guard so only the ESLint rule `context` variable is rewritten.

### Problem 2 — Ternary backward-compat pattern not collapsed

Many ESLint plugins write a ternary to support v8 and v9:
```js
context.getSourceCode ? context.getSourceCode() : context.sourceCode
```
The `??` form was already collapsed, but the ternary form was only partially handled — both branches became identical, producing broken output.

**Fix:** Added Pass 1b to detect and fully collapse the ternary to `context.sourceCode`.

### Problem 3 — Wrong arguments when receiver is a call expression

For `getSourceCode(ctx).isSpaceBetweenTokens(a, b)`, DFS `find()` picked up the inner call's arguments `(ctx)` instead of the outer `(a, b)`, producing `isSpaceBetween(ctx)`.

**Fix:** Changed `find()` to `children().find()` to get only direct children of the outer call.

---

## `@eslint/v9-to-v10-ruletester`

### Problem — `type` not removed from `map()` spread invalid test cases

ESLint v10 throws `ConfigError` on invalid test cases with a top-level `type`. The selector removed it from direct array members but missed the `map()` spread pattern:

```js
invalid: [
  ...cases.map(code => ({ type: 'CallExpression', code, errors: [...] }))
]
```

Two things blocked detection: the shorthand `code` property is a `shorthand_property_identifier` node (not `pair`), and the ancestor path through `parenthesized_expression → arrow_function → spread_element` was not modelled.

**Fix:** Added Path B for the map-spread form and updated the `code` discriminator to accept both `pair` and `shorthand_property_identifier`.

---

## Tests added

- `context-no-false-positive` — verifies utility objects are left untouched
- `context-fallback-cleanup` — extended to cover the ternary form
- `sourcecode-call-in-callee` — verifies correct args when receiver is a call expression
- `cleanup-invalid-map-spread` — verifies `type` removal in `map()` spread invalid cases