### PR TITLE
fix: use platform-native path for ignore file backups

### DIFF
--- a/.changeset/fix-ignore-backup-paths.md
+++ b/.changeset/fix-ignore-backup-paths.md
@@ -1,5 +1,5 @@
 ---
-"@eslint/v8-to-v9-config": patch
+'@eslint/v8-to-v9-config': patch
 ---
 
 Use platform-native paths when renaming processed ignore files to `deleted-eslintignore-backup.txt`.

--- a/.changeset/fix-ignore-backup-paths.md
+++ b/.changeset/fix-ignore-backup-paths.md
@@ -1,0 +1,5 @@
+---
+"@eslint/v8-to-v9-config": patch
+---
+
+Use platform-native paths when renaming processed ignore files to `deleted-eslintignore-backup.txt`.

--- a/codemods/v9/config-file/scripts/ignore-files.ts
+++ b/codemods/v9/config-file/scripts/ignore-files.ts
@@ -32,7 +32,7 @@ async function transform(root: SgRoot<JS>): Promise<string | null> {
   const fileName = root.filename()
   const fileDirectory = path.dirname(fileName)
   const relativePath = fileDirectory !== currentWorkingDirectory ? '../' : ''
-  root.rename(`${relativePath}deleted-eslintignore-backup.txt`)
+  root.rename(path.join(relativePath, 'deleted-eslintignore-backup.txt'))
 
   return null
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR simply updates the config-file migration so processed ignore files are renamed with `path.join` instead of manual string concatenation. That keeps the backup path for `deleted-eslintignore-backup.txt` platform-native across Windows and POSIX environments.

#### What changes did you make? (Give an overview)

I've ensured cross-platform behavior by using platform-native paths for ignore file backups.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
